### PR TITLE
feat(agents,physics): add PCFM correction hook (Gauss–Newton) with agent wiring and tests

### DIFF
--- a/src/constelx/agents/corrections/pcfm.py
+++ b/src/constelx/agents/corrections/pcfm.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ...eval.boundary_param import validate as validate_boundary
+from ...physics.pcfm import project_gauss_newton
+from .eci_linear import Variable as LinVariable  # reuse simple variable tuple
+
+
+@dataclass(frozen=True)
+class Term:
+    field: str
+    i: int
+    j: int
+    w: float = 1.0
+
+
+@dataclass(frozen=True)
+class NormEq:
+    terms: List[Term]
+    radius: float
+    weight: float = 1.0
+
+
+Constraint = NormEq  # minimal starter: support norm equality
+
+
+@dataclass(frozen=True)
+class PcfmSpec:
+    variables: List[LinVariable]
+    constraints: List[Constraint]
+    coeff_abs_max: float = 2.0
+    gn_iters: int = 2
+    damping: float = 1e-6
+    tol: float = 1e-8
+
+
+def _flatten(boundary: Mapping[str, Any], variables: Sequence[LinVariable]) -> NDArray[np.floating[Any]]:
+    xs: List[float] = []
+    for v in variables:
+        arr = np.asarray(boundary[v.field])
+        xs.append(float(arr[v.i, v.j]))
+    return np.asarray(xs, dtype=float)
+
+
+def _unflatten(
+    boundary: Mapping[str, Any], variables: Sequence[LinVariable], x: NDArray[np.floating[Any]]
+) -> Dict[str, Any]:
+    b = dict(boundary)
+    for v, val in zip(variables, x.tolist()):
+        arr = np.asarray(b[v.field]).copy()
+        # clamp to keep validation safe
+        arr[v.i, v.j] = float(max(-10.0, min(10.0, val)))
+        b[v.field] = arr.tolist()
+    return b
+
+
+def _build_residual_and_jac(
+    variables: Sequence[LinVariable], constraints: Sequence[Constraint]
+) -> Tuple[
+    Callable[[NDArray[np.floating[Any]]], NDArray[np.floating[Any]]],
+    Callable[[NDArray[np.floating[Any]]], NDArray[np.floating[Any]]],
+]:
+    # Map variable to index
+    index: Dict[Tuple[str, int, int], int] = {
+        (v.field, int(v.i), int(v.j)): k for k, v in enumerate(variables)
+    }
+
+    def residual(x: NDArray[np.floating[Any]]) -> NDArray[np.floating[Any]]:
+        rs: List[float] = []
+        for con in constraints:
+            # r = sum w_i x_i^2 - r^2
+            s = 0.0
+            for t in con.terms:
+                k = index[(t.field, int(t.i), int(t.j))]
+                s += float(t.w) * float(x[k]) * float(x[k])
+            rs.append(con.weight * (s - float(con.radius) * float(con.radius)))
+        return np.asarray(rs, dtype=float)
+
+    def jacobian(x: NDArray[np.floating[Any]]) -> NDArray[np.floating[Any]]:
+        m = len(constraints)
+        n = len(variables)
+        J = np.zeros((m, n), dtype=float)
+        for r, con in enumerate(constraints):
+            for t in con.terms:
+                k = index[(t.field, int(t.i), int(t.j))]
+                J[r, k] += con.weight * (2.0 * float(t.w) * float(x[k]))
+        return J
+
+    return residual, jacobian
+
+
+def make_hook(spec: PcfmSpec) -> Callable[[Mapping[str, Any]], Dict[str, Any]]:
+    residual, jac = _build_residual_and_jac(spec.variables, spec.constraints)
+
+    def hook(boundary: Mapping[str, Any]) -> Dict[str, Any]:
+        x0 = _flatten(boundary, spec.variables)
+        x = project_gauss_newton(
+            x0,
+            residual,
+            jacobian=jac,
+            max_iters=spec.gn_iters,
+            tol=spec.tol,
+            damping=spec.damping,
+        )
+        b = _unflatten(boundary, spec.variables, x)
+        # Clamp only touched fields for safety; then validate (best effort)
+        try:
+            validate_boundary(b, coeff_abs_max=spec.coeff_abs_max)
+        except Exception:
+            # If validation fails, revert to original boundary
+            return dict(boundary)
+        return b
+
+    return hook
+
+
+def build_spec_from_json(data: Sequence[Dict[str, Any]]) -> PcfmSpec:
+    # Collect variables in first-appearance order
+    var_index: Dict[Tuple[str, int, int], int] = {}
+    variables: List[LinVariable] = []
+
+    def get_var(field: str, i: int, j: int) -> LinVariable:
+        key = (field, int(i), int(j))
+        if key not in var_index:
+            var_index[key] = len(variables)
+            variables.append(LinVariable(field=field, i=int(i), j=int(j)))
+        return variables[var_index[key]]
+
+    constraints: List[Constraint] = []
+    for item in data:
+        t = str(item.get("type", "norm_eq")).lower()
+        if t != "norm_eq":
+            raise ValueError("Only 'norm_eq' is supported in the starter")
+        terms_in = item.get("terms", [])
+        terms: List[Term] = []
+        for td in terms_in:
+            field = str(td["field"])
+            i = int(td["i"])  # required
+            j = int(td["j"])  # required
+            w = float(td.get("w", 1.0))
+            get_var(field, i, j)  # register order
+            terms.append(Term(field=field, i=i, j=j, w=w))
+        radius = float(item["radius"])  # required
+        weight = float(item.get("weight", 1.0))
+        constraints.append(NormEq(terms=terms, radius=radius, weight=weight))
+
+    return PcfmSpec(variables=variables, constraints=constraints)
+
+
+__all__ = [
+    "Term",
+    "NormEq",
+    "PcfmSpec",
+    "make_hook",
+    "build_spec_from_json",
+]
+

--- a/src/constelx/agents/corrections/pcfm.py
+++ b/src/constelx/agents/corrections/pcfm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Sequence, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -39,7 +39,10 @@ class PcfmSpec:
     tol: float = 1e-8
 
 
-def _flatten(boundary: Mapping[str, Any], variables: Sequence[LinVariable]) -> NDArray[np.floating[Any]]:
+def _flatten(
+    boundary: Mapping[str, Any],
+    variables: Sequence[LinVariable],
+) -> NDArray[np.floating[Any]]:
     xs: List[float] = []
     for v in variables:
         arr = np.asarray(boundary[v.field])
@@ -159,4 +162,3 @@ __all__ = [
     "make_hook",
     "build_spec_from_json",
 ]
-

--- a/src/constelx/agents/simple_agent.py
+++ b/src/constelx/agents/simple_agent.py
@@ -138,6 +138,18 @@ def _build_eci_linear_hook(constraints: List[Dict[str, Any]]) -> Optional[_Corre
     return make_hook(spec)
 
 
+def _build_pcfm_hook(constraints: List[Dict[str, Any]]) -> Optional[_CorrectionHook]:
+    try:
+        from .corrections.pcfm import PcfmSpec, build_spec_from_json, make_hook
+    except Exception:
+        return None
+    try:
+        spec: PcfmSpec = build_spec_from_json(constraints)
+    except Exception:
+        return None
+    return make_hook(spec)
+
+
 def run(config: AgentConfig) -> Path:
     """Run a tiny random-search agent loop and write artifacts.
 
@@ -234,6 +246,8 @@ def run(config: AgentConfig) -> Path:
     hook: Optional[_CorrectionHook] = None
     if config.correction == "eci_linear" and config.constraints:
         hook = _build_eci_linear_hook(config.constraints)
+    elif config.correction == "pcfm" and config.constraints:
+        hook = _build_pcfm_hook(config.constraints)
 
     def maybe_correct(bnd: Dict[str, Any]) -> Dict[str, Any]:
         if hook is None:

--- a/src/constelx/cli.py
+++ b/src/constelx/cli.py
@@ -276,8 +276,11 @@ def agent_run(
     ),
     constraints_file: Optional[Path] = typer.Option(
         None,
-        help="JSON file with linear constraints for --correction eci_linear.\n"
-        "Format: [{rhs: float, coeffs: [{field,i,j,c}]}]",
+        help=(
+            "JSON file with constraints for correction hooks.\n"
+            "- eci_linear: [{rhs: float, coeffs: [{field,i,j,c}]}]\n"
+            "- pcfm: [{type:'norm_eq', radius:float, terms:[{field,i,j,w}]}]"
+        ),
     ),
 ) -> None:
     from .agents.simple_agent import AgentConfig, run as run_agent  # noqa: I001

--- a/src/constelx/physics/pcfm.py
+++ b/src/constelx/physics/pcfm.py
@@ -1,28 +1,113 @@
-"""Physics-Constrained Flow Matching (PCFM) — placeholder
+"""Physics-Constrained Flow Matching (PCFM) — core projection utilities.
 
-Use this module to integrate a pretrained flow model while projecting
-intermediate states onto hard constraints (equality type), e.g., global
-conservation, boundary values, local flux constraints.
+This module provides a small, dependency-light Gauss–Newton projector to
+enforce nonlinear equality constraints of the form ``h(u) = 0`` on a vector of
+parameters ``u``. It is used by the agent's optional "pcfm" correction hook to
+adjust boundary Fourier coefficients before evaluation.
 
-Key ideas to implement:
-- Forward 'shoot' to t=1, Gauss–Newton projection on constraint manifold.
-- Reverse update via OT displacement interpolant (stable approx of reverse flow).
-- Optional relaxed correction with penalty on residuals.
-- Final projection to enforce h(u1)=0 to numerical precision.
+The implementation uses a damped least-squares Gauss–Newton step with optional
+finite-difference Jacobians, backtracking line search, and safety fallbacks.
 """
 
-from typing import Any, Callable
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def finite_diff_jacobian(
+    fun: Callable[[NDArray[np.floating[Any]]], NDArray[np.floating[Any]]],
+    u: NDArray[np.floating[Any]],
+    *,
+    eps: Optional[float] = None,
+) -> NDArray[np.floating[Any]]:
+    """Compute a finite-difference Jacobian of ``fun`` at ``u``.
+
+    Uses simple forward differences with element-wise step sizes scaled to the
+    magnitude of ``u``. This is sufficient for the small dimensionalities used
+    in the starter and keeps dependencies minimal.
+    """
+    u = np.asarray(u, dtype=float)
+    f0 = np.asarray(fun(u), dtype=float)
+    m = int(f0.size)
+    n = int(u.size)
+    J = np.zeros((m, n), dtype=float)
+    # Per-coordinate step
+    for j in range(n):
+        h = (1e-6 if eps is None else float(eps)) * (1.0 + abs(float(u[j])))
+        uj = float(u[j])
+        u[j] = uj + h
+        fj = np.asarray(fun(u), dtype=float)
+        u[j] = uj
+        J[:, j] = (fj - f0) / h
+    return J
 
 
 def project_gauss_newton(
-    u: Any, residual: Callable[[Any], Any], jacobian: Callable[[Any], Any]
-) -> Any:
-    """One Gauss–Newton projection step onto linearized constraints."""
-    # TODO: implement
-    return u
+    u: NDArray[np.floating[Any]],
+    residual: Callable[[NDArray[np.floating[Any]]], NDArray[np.floating[Any]]],
+    jacobian: Optional[Callable[[NDArray[np.floating[Any]]], NDArray[np.floating[Any]]]] = None,
+    *,
+    max_iters: int = 3,
+    tol: float = 1e-8,
+    damping: float = 1e-6,
+    backtracking: bool = True,
+    max_backtracks: int = 5,
+) -> NDArray[np.floating[Any]]:
+    """Project ``u`` toward the manifold ``{u | h(u)=0}`` via damped Gauss–Newton.
+
+    Solves at each iteration the damped least-squares subproblem::
+
+        minimize 0.5||J du + h||^2 + 0.5*lambda*||du||^2
+
+    using a stable least-squares formulation. Performs a short line-search to
+    ensure residual reduction. Returns the updated vector (never raises).
+    """
+    x = np.asarray(u, dtype=float).copy()
+    lam = float(damping)
+    for _ in range(max_iters):
+        h = np.asarray(residual(x), dtype=float)
+        norm_h = float(np.linalg.norm(h))
+        if not np.isfinite(norm_h) or norm_h <= tol:
+            break
+        J = (
+            finite_diff_jacobian(residual, x)
+            if jacobian is None
+            else np.asarray(jacobian(x), dtype=float)
+        )
+        m, n = J.shape
+        # Build damped least-squares system: [J; sqrt(lam) I] du = [-h; 0]
+        A = np.vstack([J, np.sqrt(lam) * np.eye(n, dtype=float)])
+        b = np.concatenate([-h, np.zeros(n, dtype=float)])
+        try:
+            du, *_ = np.linalg.lstsq(A, b, rcond=None)
+        except np.linalg.LinAlgError:
+            du = -np.linalg.pinv(J) @ h
+
+        # Backtracking line search on residual decrease
+        alpha = 1.0
+        accepted = False
+        for _bt in range(max_backtracks if backtracking else 1):
+            x_new = x + alpha * du
+            h_new = np.asarray(residual(x_new), dtype=float)
+            if np.linalg.norm(h_new) < norm_h:
+                x = x_new
+                accepted = True
+                break
+            alpha *= 0.5
+        if not accepted:
+            # Increase damping and try next GN iteration from same x
+            lam *= 10.0
+        # Convergence check next loop via h(x)
+    return x
 
 
 def guided_step(u: Any, model: Any, t: float, dt: float, constraint: Callable[[Any], Any]) -> Any:
-    """One PCFM-guided update step."""
-    # TODO: implement
+    """Placeholder for a PCFM-guided update step (not used in starter)."""
+    # Intentionally left minimal; end-to-end uses the projector above.
     return u
+
+
+__all__ = ["finite_diff_jacobian", "project_gauss_newton", "guided_step"]

--- a/tests/test_cli_agent_pcfm.py
+++ b/tests/test_cli_agent_pcfm.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_agent_with_pcfm_norm_constraint_runs_and_applies(tmp_path: Path) -> None:
+    # Constrain (r_cos[1][5], z_sin[1][5]) to lie on circle of radius 0.06
+    constraints = [
+        {
+            "type": "norm_eq",
+            "radius": 0.06,
+            "terms": [
+                {"field": "r_cos", "i": 1, "j": 5, "w": 1.0},
+                {"field": "z_sin", "i": 1, "j": 5, "w": 1.0},
+            ],
+        }
+    ]
+    constraints_path = tmp_path / "constraints.json"
+    constraints_path.write_text(json.dumps(constraints))
+
+    runner = CliRunner()
+    runs_dir = tmp_path / "runs"
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--nfp",
+            "3",
+            "--budget",
+            "4",
+            "--seed",
+            "0",
+            "--runs-dir",
+            str(runs_dir),
+            "--correction",
+            "pcfm",
+            "--constraints-file",
+            str(constraints_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Verify proposals exist and first boundary satisfies the norm constraint approximately
+    subdirs = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert len(subdirs) == 1
+    out = subdirs[0]
+    proposals = (out / "proposals.jsonl").read_text().splitlines()
+    assert len(proposals) >= 1
+    first = json.loads(proposals[0])
+    b = first["boundary"]
+    x = float(b["r_cos"][1][5])
+    y = float(b["z_sin"][1][5])
+    assert abs((x * x + y * y) - 0.06 * 0.06) < 1e-4
+

--- a/tests/test_cli_agent_pcfm.py
+++ b/tests/test_cli_agent_pcfm.py
@@ -57,4 +57,3 @@ def test_agent_with_pcfm_norm_constraint_runs_and_applies(tmp_path: Path) -> Non
     x = float(b["r_cos"][1][5])
     y = float(b["z_sin"][1][5])
     assert abs((x * x + y * y) - 0.06 * 0.06) < 1e-4
-

--- a/tests/test_correction_pcfm.py
+++ b/tests/test_correction_pcfm.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import math
 
-import numpy as np
-
 from constelx.agents.corrections.eci_linear import Variable as LinVar
 from constelx.agents.corrections.pcfm import (
     NormEq,
@@ -39,4 +37,3 @@ def test_pcfm_norm_eq_projects_to_circle_min_change() -> None:
     theta0 = math.atan2(0.02, -0.12)
     theta = math.atan2(x2, x1)
     assert abs((theta - theta0 + math.pi) % (2 * math.pi) - math.pi) < 1e-3
-

--- a/tests/test_correction_pcfm.py
+++ b/tests/test_correction_pcfm.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from constelx.agents.corrections.eci_linear import Variable as LinVar
+from constelx.agents.corrections.pcfm import (
+    NormEq,
+    PcfmSpec,
+    Term,
+    make_hook,
+)
+from constelx.physics.constel_api import example_boundary
+
+
+def test_pcfm_norm_eq_projects_to_circle_min_change() -> None:
+    b = example_boundary()
+    # Variables: r_cos[1][5] and z_sin[1][5]
+    v1 = LinVar("r_cos", 1, 5)
+    v2 = LinVar("z_sin", 1, 5)
+
+    # Build a norm equality: w1 x1^2 + w2 x2^2 = r^2
+    radius = 0.08
+    con = NormEq(terms=[Term("r_cos", 1, 5, 1.0), Term("z_sin", 1, 5, 1.0)], radius=radius)
+    spec = PcfmSpec(variables=[v1, v2], constraints=[con], gn_iters=3)
+    hook = make_hook(spec)
+
+    # Perturb away from the circle
+    b["r_cos"][1][5] = float(-0.12)
+    b["z_sin"][1][5] = float(0.02)
+    b2 = hook(b)
+    x1 = float(b2["r_cos"][1][5])
+    x2 = float(b2["z_sin"][1][5])
+    # Residual should be close to zero
+    r = (x1 * x1 + x2 * x2) - (radius * radius)
+    assert abs(r) < 1e-6
+    # Update direction should move toward radial projection (angle preserved)
+    theta0 = math.atan2(0.02, -0.12)
+    theta = math.atan2(x2, x1)
+    assert abs((theta - theta0 + math.pi) % (2 * math.pi) - math.pi) < 1e-3
+


### PR DESCRIPTION
This PR adds a minimal, robust PCFM correction hook and wires it into the agent and CLI.

Summary
- Physics: damped Gauss–Newton projector with finite-difference fallback Jacobian (NumPy-only), backtracking line search, and damping schedule.
- Agent: new `pcfm` correction hook using a JSON spec (currently supports `norm_eq` constraints over selected Fourier coefficients).
- CLI: `--constraints-file` help extended to document `pcfm` spec format.
- Tests: unit test for the norm-equality projection and a CLI integration test that enforces the constraint in an agent run.
- Pre-commit: hooks run clean (ruff format/check, mypy strict).

Spec example (pcfm):
[
  {
    "type": "norm_eq",
    "radius": 0.06,
    "terms": [
      {"field": "r_cos", "i": 1, "j": 5, "w": 1.0},
      {"field": "z_sin", "i": 1, "j": 5, "w": 1.0}
    ]
  }
]

Artifacts
- No schema changes to run artifacts; agent behavior unchanged unless `--correction pcfm` is passed.

Testing
- `pytest -q`: all tests pass locally.
- Pre-commit: ruff + mypy strict + whitespace hooks pass.

Closes #8.
