### PR TITLE
feat(pcfm): add ratio_eq and product_eq constraints with analytic Jacobians + tests

### DIFF
--- a/tests/test_cli_agent_pcfm_ratio.py
+++ b/tests/test_cli_agent_pcfm_ratio.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_agent_with_pcfm_ratio_constraint(tmp_path: Path) -> None:
+    # Enforce z_sin[1][5]/r_cos[1][5] = -1.25
+    constraints = [
+        {
+            "type": "ratio_eq",
+            "target": -1.25,
+            "num": {"field": "z_sin", "i": 1, "j": 5},
+            "den": {"field": "r_cos", "i": 1, "j": 5},
+            "eps": 1e-6,
+        }
+    ]
+    constraints_path = tmp_path / "constraints.json"
+    constraints_path.write_text(json.dumps(constraints))
+
+    runner = CliRunner()
+    runs_dir = tmp_path / "runs"
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--nfp",
+            "3",
+            "--budget",
+            "3",
+            "--seed",
+            "1",
+            "--runs-dir",
+            str(runs_dir),
+            "--correction",
+            "pcfm",
+            "--pcfm-gn-iters",
+            "3",
+            "--constraints-file",
+            str(constraints_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    out = next(p for p in runs_dir.iterdir() if p.is_dir())
+    first = json.loads((out / "proposals.jsonl").read_text().splitlines()[0])
+    b = first["boundary"]
+    x = float(b["r_cos"][1][5])
+    y = float(b["z_sin"][1][5])
+    ratio = y / (x + 1e-6)
+    assert abs(ratio - (-1.25)) < 1e-3

--- a/tests/test_correction_pcfm_ratio_product.py
+++ b/tests/test_correction_pcfm_ratio_product.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import math
+
+from constelx.agents.corrections.eci_linear import Variable as LinVar
+from constelx.agents.corrections.pcfm import (
+    PcfmSpec,
+    ProductEq,
+    RatioEq,
+    Var,
+    make_hook,
+)
+from constelx.physics.constel_api import example_boundary
+
+
+def test_pcfm_ratio_eq_projects_to_target() -> None:
+    b = example_boundary()
+    v1 = LinVar("r_cos", 1, 5)
+    v2 = LinVar("z_sin", 1, 5)
+    # Start away from target ratio
+    b["r_cos"][1][5] = float(-0.10)
+    b["z_sin"][1][5] = float(0.02)
+
+    con = RatioEq(num=Var("z_sin", 1, 5), den=Var("r_cos", 1, 5), target=-1.5, eps=1e-6)
+    spec = PcfmSpec(variables=[v1, v2], constraints=[con], gn_iters=3)
+    hook = make_hook(spec)
+    b2 = hook(b)
+    x = float(b2["r_cos"][1][5])
+    y = float(b2["z_sin"][1][5])
+    ratio = y / (x + 1e-6)
+    assert math.isfinite(ratio)
+    # Allow small GN approximation error
+    assert abs(ratio - (-1.5)) < 2e-3
+
+
+def test_pcfm_product_eq_projects_to_target() -> None:
+    b = example_boundary()
+    v1 = LinVar("r_cos", 1, 5)
+    v2 = LinVar("z_sin", 1, 5)
+    # Start away from target product
+    b["r_cos"][1][5] = float(-0.12)
+    b["z_sin"][1][5] = float(0.02)
+
+    target = 0.003
+    con = ProductEq(a=Var("r_cos", 1, 5), b=Var("z_sin", 1, 5), target=target)
+    spec = PcfmSpec(variables=[v1, v2], constraints=[con], gn_iters=3)
+    hook = make_hook(spec)
+    b2 = hook(b)
+    x = float(b2["r_cos"][1][5])
+    y = float(b2["z_sin"][1][5])
+    prod = x * y
+    assert math.isfinite(prod)
+    assert abs(prod - target) < 1e-6


### PR DESCRIPTION
This PR extends the PCFM correction hook to support additional constraint types and adds tests.

What’s included
- Constraint types:
  - ratio_eq: enforce y/(x+eps) = target with eps guards and weights.
  - product_eq: enforce x*y = target with weights.
  - (Existing) norm_eq remains supported; constraints can be stacked.
- Implementation:
  - Analytic residuals and Jacobians for ratio and product for stability and speed.
  - JSON parsing for the new types; order-stable variable mapping.
- Tests:
  - Unit: ratio and product projection accuracy with a few GN steps.
  - CLI integration: agent run with a ratio_eq constraint applies the projection to proposals.
- Pre-commit: ruff + ruff-format + mypy strict — clean.

Why
- Many physics relationships are naturally ratios or products of coefficients; adding these expands constraint expressiveness while retaining stable numerics.

Notes
- Solver uses existing LM-damped Gauss–Newton with backtracking; remains NumPy-only.
- Tolerances are set to keep tests fast and robust in CI.

Related: #18
