### PR TITLE
fix(physics): handle multidimensional gradients in conflict-free update

### DIFF
--- a/src/constelx/physics/pbfm.py
+++ b/src/constelx/physics/pbfm.py
@@ -44,9 +44,9 @@ def conflict_free_update(g_fm: ArrayLike, g_r: ArrayLike) -> NDArray[np.floating
     if g_fm_arr.shape != g_r_arr.shape:
         raise ValueError("g_fm and g_r must have the same shape")
 
-    dot = float(np.dot(g_fm_arr, g_r_arr))
+    dot = float(np.vdot(g_fm_arr, g_r_arr))
     if dot < 0.0:
-        proj = (dot / np.dot(g_fm_arr, g_fm_arr)) * g_fm_arr
+        proj = (dot / np.vdot(g_fm_arr, g_fm_arr)) * g_fm_arr
         g_r_arr = g_r_arr - proj
 
     def _unit(x: NDArray[np.floating[Any]]) -> NDArray[np.floating[Any]]:

--- a/tests/test_pbfm.py
+++ b/tests/test_pbfm.py
@@ -32,6 +32,14 @@ def test_conflict_free_update_cooperative() -> None:
     assert np.allclose(update, expected)
 
 
+def test_conflict_free_update_matrix_gradients() -> None:
+    g_fm = np.array([[1.0], [0.0]])
+    g_r = np.array([[-1.0], [1.0]])
+    update = conflict_free_update(g_fm, g_r)
+    expected = np.array([[1.0], [1.0]]) / np.sqrt(2.0)
+    assert np.allclose(update, expected)
+
+
 def test_conflict_free_update_shape_mismatch() -> None:
     g_fm = np.array([1.0, 0.0])
     g_r = np.array([0.0, 1.0, 2.0])


### PR DESCRIPTION
## Summary
- avoid crash on multi-dimensional gradients by using `np.vdot`
- add regression test for matrix-shaped gradients

## Testing
- `ruff format .`
- `ruff check .`
- `mypy src/constelx`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf47c9d908329a6707e62e4c239ba