### PR TITLE
feat(problems): add ProblemSpec for P1–P3 + CLI listing

### DIFF
--- a/src/constelx/problems/__init__.py
+++ b/src/constelx/problems/__init__.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ProblemSpec:
+    """Lightweight problem specification for P1–P3.
+
+    Fields are intentionally minimal and decoupled from the external evaluator
+    so the starter can document expectations and perform gentle validation
+    without adding hard dependencies.
+    """
+
+    pid: str
+    name: str
+    required_metrics: Tuple[str, ...]
+    optional_metrics: Tuple[str, ...] = ()
+    description: str = ""
+
+    def missing_keys(self, metrics: Mapping[str, object]) -> List[str]:
+        present = set(metrics.keys())
+        return [k for k in self.required_metrics if k not in present]
+
+
+def _p1() -> ProblemSpec:
+    # Geometric single-objective; external evaluator typically returns
+    # at least {objective, score, feasibility}. Keep requirements minimal.
+    return ProblemSpec(
+        pid="p1",
+        name="Geometric shaping",
+        required_metrics=("score",),
+        optional_metrics=("objective", "feasibility"),
+        description="Single-objective geometry task; lower is better.",
+    )
+
+
+def _p2() -> ProblemSpec:
+    return ProblemSpec(
+        pid="p2",
+        name="Simple-to-build QI",
+        required_metrics=("score",),
+        optional_metrics=("objective", "feasibility"),
+        description="QI with coil-simplicity proxy; single-objective.",
+    )
+
+
+def _p3() -> ProblemSpec:
+    # Multi-objective; external returns a scalar score and a list of objectives
+    # or separate objective_k entries. Require score; advise objectives.
+    return ProblemSpec(
+        pid="p3",
+        name="MHD-stable QI multi-objective",
+        required_metrics=("score",),
+        optional_metrics=("objectives", "objective_0", "objective_1", "feasibility"),
+        description="Multi-objective with Pareto analysis; scalar score present for ranking.",
+    )
+
+
+_REGISTRY: Dict[str, ProblemSpec] = {
+    "p1": _p1(),
+    "geom": _p1(),
+    "geometric": _p1(),
+    "geometrical": _p1(),
+    "p2": _p2(),
+    "simple": _p2(),
+    "qi_simple": _p2(),
+    "simple_qi": _p2(),
+    "p3": _p3(),
+    "multi": _p3(),
+    "mhd": _p3(),
+    "qi_stable": _p3(),
+}
+
+
+def get_spec(problem: str) -> Optional[ProblemSpec]:
+    return _REGISTRY.get(problem.lower().strip())
+
+
+def list_specs() -> Iterable[ProblemSpec]:
+    # Return canonical P1, P2, P3 in order
+    yield _REGISTRY["p1"]
+    yield _REGISTRY["p2"]
+    yield _REGISTRY["p3"]
+
+
+__all__ = ["ProblemSpec", "get_spec", "list_specs"]


### PR DESCRIPTION
Summary
- Add lightweight ProblemSpec registry for P1–P3 under src/constelx/problems
- New CLI: `constelx eval problems` to list known problems and expected metrics
- `constelx eval score --metrics-json`: gentle warning if metrics are missing expected keys for the chosen problem (non-blocking)

Rationale
This addresses part of #31 (problem specs + CLI docs) by documenting the expected shape of metrics for P1/P2 (single-objective) and P3 (multi-objective) without hard-coupling to external evaluator internals. It improves discoverability (`eval problems`) and provides guidance for downstream tooling and tests.

Notes
- No breaking changes; all existing commands continue to work as before
- Warnings in `eval score` only appear when using `--metrics-json`
- Aggregation still delegates to official scorer when available (and placeholder otherwise)

Testing
- Local equivalents: `ruff format`, `ruff check --fix`, `mypy src/constelx`, `pytest -q` (42 passed)
- Verified `constelx eval problems` renders table; `constelx eval score --metrics-json ... --problem p3` prints a friendly warning if `objectives` are missing

Follow-ups
- Complete #31 by expanding problem docs and references in README/CLI help
- Add P2/P3 scoring parity tests with small goldens (#33)
- Wire provenance assertions in tests for robustness (#34)

Refs: #31