### PR TITLE
feat: add basic geometry constraint metrics

### DIFF
--- a/src/constelx/physics/constraints.py
+++ b/src/constelx/physics/constraints.py
@@ -2,14 +2,71 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+
+def _base_and_minor(boundary: Dict[str, Any]) -> Tuple[float, float]:
+    """Return approximations of (major radius R0, minor radius a)."""
+    r_cos = boundary.get("r_cos")
+    z_sin = boundary.get("z_sin")
+    if not (
+        isinstance(r_cos, list)
+        and r_cos
+        and isinstance(r_cos[0], list)
+        and isinstance(z_sin, list)
+        and len(z_sin) > 1
+        and isinstance(z_sin[1], list)
+        and len(r_cos) > 1
+        and isinstance(r_cos[1], list)
+    ):
+        return 0.0, 0.0
+    j0 = min(4, len(r_cos[0]) - 1, len(r_cos[1]) - 1, len(z_sin[1]) - 1)
+    try:
+        r0 = float(r_cos[0][j0])
+        r1 = float(r_cos[1][j0])
+        z1 = float(z_sin[1][j0])
+    except (TypeError, ValueError, IndexError):
+        return 0.0, 0.0
+    minor = float(np.hypot(r1, z1))
+    return r0, minor
 
 
 def aspect_ratio(boundary: Dict[str, Any]) -> float:
-    # TODO: compute major/minor radii from Fourier coeffs
-    return 0.0
+    """Approximate aspect ratio as ``R0 / a`` from Fourier coefficients.
+
+    ``R0`` is taken from the base radius coefficient and ``a`` from the
+    magnitude of the ``m=1`` terms. Returns ``0.0`` when unavailable or
+    degenerate.
+    """
+    r0, minor = _base_and_minor(boundary)
+    if minor <= 0.0:
+        return 0.0
+    return abs(r0) / minor
 
 
 def curvature_smoothness(boundary: Dict[str, Any]) -> float:
-    # TODO: compute curvature integral along poloidal angle
-    return 0.0
+    """Rough smoothness proxy based on second differences of ``m=1`` terms."""
+    r_cos = boundary.get("r_cos")
+    z_sin = boundary.get("z_sin")
+    if not (
+        isinstance(r_cos, list)
+        and len(r_cos) > 1
+        and isinstance(r_cos[1], list)
+        and isinstance(z_sin, list)
+        and len(z_sin) > 1
+        and isinstance(z_sin[1], list)
+    ):
+        return 0.0
+    r1 = np.asarray(r_cos[1], dtype=float)
+    z1 = np.asarray(z_sin[1], dtype=float)
+    if r1.size < 3 or z1.size < 3:
+        return 0.0
+    dr2 = np.diff(r1, n=2)
+    dz2 = np.diff(z1, n=2)
+    curv = dr2 * dr2 + dz2 * dz2
+    return float(np.mean(curv)) if curv.size else 0.0
+
+
+__all__ = ["aspect_ratio", "curvature_smoothness"]

--- a/src/constelx/physics/pcfm.py
+++ b/src/constelx/physics/pcfm.py
@@ -65,7 +65,7 @@ def project_gauss_newton(
     using a stable least-squares formulation. Performs a short line-search to
     ensure residual reduction. Returns the updated vector (never raises).
     """
-    x = np.asarray(u, dtype=float).copy()
+    x: NDArray[np.floating[Any]] = np.asarray(u, dtype=float).copy()
     lam = float(damping)
     for _ in range(max_iters):
         h = np.asarray(residual(x), dtype=float)

--- a/tests/test_physics_constraints.py
+++ b/tests/test_physics_constraints.py
@@ -1,0 +1,51 @@
+import copy
+
+import pytest
+
+from constelx.physics.constraints import aspect_ratio, curvature_smoothness
+
+
+def _base_boundary() -> dict:
+    b = {
+        "r_cos": [[0.0 for _ in range(6)] for _ in range(2)],
+        "r_sin": None,
+        "z_cos": None,
+        "z_sin": [[0.0 for _ in range(6)] for _ in range(2)],
+        "n_field_periods": 3,
+        "is_stellarator_symmetric": True,
+    }
+    for j in range(6):
+        b["r_cos"][1][j] = 0.1
+        b["z_sin"][1][j] = 0.2
+    b["r_cos"][0][4] = 1.0
+    return b
+
+
+def test_aspect_ratio_simple() -> None:
+    b = _base_boundary()
+    ar = aspect_ratio(b)
+    assert ar == pytest.approx(4.4721, rel=1e-3)
+
+
+def test_curvature_smoothness_variation() -> None:
+    b_const = _base_boundary()
+    smooth0 = curvature_smoothness(b_const)
+    assert smooth0 == pytest.approx(0.0)
+
+    b_var = copy.deepcopy(b_const)
+    b_var["r_cos"][1][1] = 0.05
+    b_var["z_sin"][1][2] = 0.1
+    assert curvature_smoothness(b_var) > smooth0
+
+
+def test_aspect_ratio_missing_coeffs() -> None:
+    b = {"r_cos": [[0.0]], "z_sin": [[0.0]]}
+    assert aspect_ratio(b) == 0.0
+
+
+def test_curvature_smoothness_short_series() -> None:
+    b = {
+        "r_cos": [[0.0 for _ in range(2)] for _ in range(2)],
+        "z_sin": [[0.0 for _ in range(2)] for _ in range(2)],
+    }
+    assert curvature_smoothness(b) == 0.0


### PR DESCRIPTION
## Summary
- add aspect ratio and curvature smoothness utilities in physics constraints
- fix Gauss–Newton projector typing for mypy
- test aspect ratio and curvature helpers
- refine geometry helpers with safer hypot computation and public exports
- expand edge-case tests for missing coefficients

## Testing
- `ruff check src/constelx/physics/constraints.py src/constelx/physics/pcfm.py tests/test_physics_constraints.py`
- `mypy --strict src/constelx`
- `pytest -q` *(fails: ModuleNotFoundError: typer, constelx)*
- `pytest tests/test_physics_constraints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff98ee9d4832999e1d06b359721bb