### PR TITLE
fix(agent): preserve phase with single-worker proxy gating

### DIFF
--- a/src/constelx/agents/simple_agent.py
+++ b/src/constelx/agents/simple_agent.py
@@ -528,7 +528,7 @@ def run(config: AgentConfig) -> Path:
             # Evaluate
             if not batch:
                 break
-            if config.max_workers > 1:
+            if config.max_workers > 1 or config.mf_proxy:
                 from ..eval import forward_many
 
                 results = forward_many(


### PR DESCRIPTION
## Summary
- route single-worker agent evaluations through `forward_many` when `mf_proxy` is enabled so metrics capture the `phase` field

## Testing
- `ruff format src/constelx/agents/simple_agent.py`
- `ruff check src/constelx/agents/simple_agent.py`
- `mypy src/constelx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02a7ce4f08329a108240c946bfb55