### PR TITLE
refactor: speed up dataset fetch and surrogate training

### DIFF
--- a/src/constelx/cli.py
+++ b/src/constelx/cli.py
@@ -80,12 +80,8 @@ def data_fetch(
     # synthetic path
     from .data.dataset import fetch_dataset, save_subset
 
-    ds = fetch_dataset()
-    if nfp is not None:
-        # Use single-process filter to avoid fork issues in constrained environments/tests
-        ds = ds.filter(lambda x: x == nfp, input_columns=["boundary.n_field_periods"], num_proc=1)
-    if limit is not None:
-        ds = ds.select(range(min(limit, len(ds))))
+    count = int(limit) if limit is not None else 128
+    ds = fetch_dataset(count=count, nfp=int(nfp) if nfp is not None else 3)
     out = save_subset(ds, cache_dir)
     console.print(f"Saved subset to: [bold]{out}[/bold]")
 
@@ -400,11 +396,14 @@ def surrogate_train(
         Path("outputs/surrogates/mlp"), "--out-dir", "--output-dir", help="Model output directory"
     ),
     use_pbfm: bool = typer.Option(False, help="Use PBFM conflict-free loss combination"),
+    steps: int = typer.Option(20, help="Number of optimizer steps"),
 ) -> None:
     from .surrogate.train import train_simple_mlp
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    train_simple_mlp(cache_dir=cache_dir, output_dir=output_dir, use_pbfm=use_pbfm)
+    train_simple_mlp(
+        cache_dir=cache_dir, output_dir=output_dir, use_pbfm=use_pbfm, steps=int(steps)
+    )
     console.print(f"Saved surrogate to {output_dir}")
 
 

--- a/src/constelx/surrogate/train.py
+++ b/src/constelx/surrogate/train.py
@@ -32,7 +32,9 @@ class MLP(nn.Module):
         return cast(torch.Tensor, self.net(x))
 
 
-def train_simple_mlp(cache_dir: Path, output_dir: Path, *, use_pbfm: bool = False) -> None:
+def train_simple_mlp(
+    cache_dir: Path, output_dir: Path, *, use_pbfm: bool = False, steps: int = 20
+) -> None:
     df = pd.read_parquet(Path(cache_dir) / "subset.parquet")
     X = df[_boundary_cols(df)].fillna(0.0).to_numpy()
     # Toy target: pick one available scalar metric if present, else zeros
@@ -49,7 +51,7 @@ def train_simple_mlp(cache_dir: Path, output_dir: Path, *, use_pbfm: bool = Fals
     model = MLP(X.shape[1], 1)
     opt = optim.Adam(model.parameters(), lr=3e-4)
 
-    for _ in range(200):
+    for _ in range(int(steps)):
         if not use_pbfm:
             opt.zero_grad()
             pred = model(X)


### PR DESCRIPTION
## Summary
- fetch only the requested number of synthetic records and allow NFP selection without extra filtering
- expose optimizer steps in `surrogate train` and default to fewer iterations to shorten CI
- support configurable step count in `train_simple_mlp` and lower default to 20 so tests run quickly

## Testing
- `pre-commit run --files src/constelx/surrogate/train.py src/constelx/cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0e14e111c8329b27fa0134ba146d4