### PR TITLE
chore: ignore .cache and document evaluator cache/TTL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/
 !src/constelx/data/
 outputs/
 runs/
+.cache/
 .env
 .mpl_cache/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ The CLI and evaluator auto-load a local `.env` if `python-dotenv` is installed (
 - `CONSTELX_REAL_TIMEOUT_MS`: per-call timeout in milliseconds (default `20000`).
 - `CONSTELX_REAL_RETRIES`: number of retries on timeout/error (default `1`).
 - `CONSTELX_REAL_BACKOFF`: multiplicative backoff factor between retries (default `1.5`).
+ - `CONSTELX_CACHE_TTL_SECONDS`: optional TTL (in seconds) for evaluator cache entries when
+   `diskcache` is available (install with `.[cache]`). After TTL, cached results expire and will be
+   recomputed. JSON fallback ignores TTL.
+
+Caching
+- Evaluator results are cached to speed up repeated calls. Default cache dir is `.cache/eval/`.
+- To keep repositories clean and runs isolated, prefer per-run caches:
+  pass `--cache-dir runs/<ts>/cache` to `constelx eval/agent` commands. The `runs/` tree is ignored.
 
 Artifacts now include clear scoring and provenance fields:
 - CSV: `evaluator_score`, `agg_score`, `elapsed_ms`, `feasible`, `fail_reason`, `source`.


### PR DESCRIPTION
Summary
- Add `.cache/` to `.gitignore` to avoid committing evaluator cache artifacts.
- Document `CONSTELX_CACHE_TTL_SECONDS` and recommend per-run cache dir (`--cache-dir runs/<ts>/cache`) in README.

Rationale
- Cache files are transient and should not be versioned.
- Per-run caches keep experiments isolated; TTL bounds staleness/growth when using the `diskcache` extra.

Testing
- Verified that `.cache/eval/*.json` no longer show up in `git status`.

Notes
- TTL applies only when `diskcache` is installed via `.[cache]`; JSON fallback ignores TTL.