### PR TITLE
feat: ablation harness for pipeline components (CLI + spec) — Closes #53

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ These guidelines help contributors build, test, and extend the ConStelX starter 
 - Commits: Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
 - PRs: < ~400 LOC, green `ruff` + `mypy` + `pytest`, include docs and a minimal example.
 - Description: what/why, linked issues, CLI example (if applicable), and notes on performance.
+- Auto-close issues on merge: when a PR fully resolves an issue, include closing keywords in the PR description so GitHub closes them automatically on merge. Examples: `Closes #123`, `Fixes owner/repo#456`, `Resolves #789`. Keep these only when the PR truly completes the issue.
+- Auto-merge: it’s fine to enable GitHub’s auto-merge once checks are green. For PRs that should close issues on merge, ensure closing keywords are present in the PR description before enabling auto-merge.
 
 ## Architecture & Ops Notes
 
@@ -125,7 +127,7 @@ Required pieces:
 - Include a `README.md` in each run folder with CLI used and env info.
 
 Artifacts fields (clarity and provenance)
-- CSV columns include: `evaluator_score` (from official evaluator when present), `agg_score` (our aggregated score), `elapsed_ms` (per‑eval time), `feasible` (bool), `fail_reason` (string), and `source` (`placeholder|real`).
+- CSV columns include: `nfp`, `evaluator_score` (from official evaluator when present), `agg_score` (our aggregated score), `elapsed_ms` (per‑eval time), `feasible` (bool), `fail_reason` (string), and `source` (`placeholder|real`).
 - When multi‑fidelity gating is enabled, a `phase` column indicates `proxy` or `real` evaluation phase for each row. Proxy results are cached separately from real results.
 - `best.json` stores `agg_score` (and a backward‑compatible `score` alias), optional `evaluator_score`, and a `metrics` object without a conflicting `score` key.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Agent
    - Thresholds can be tuned: `--guard-r0-min`, `--guard-r0-max`, and
      `--guard-helical-ratio-max`.
 
- 
+
  - PCFM correction (examples):
    - Norm equality: constrain helical amplitude to a circle of radius 0.06
      - JSON: `examples/pcfm_norm.json`

--- a/README.md
+++ b/README.md
@@ -63,21 +63,30 @@ Agent
 - CMA-ES (falls back to random if cma missing):
   `constelx agent run --nfp 3 --budget 20 --algo cmaes --seed 0`
 - Resume a run: `constelx agent run --nfp 3 --budget 10 --resume runs/<ts>`
+- Multi-start NFP exploration (round-robin across values):
+  `constelx agent run --nfp-list "3,4,5" --budget 12 --seed 0`
+  The budget is shared across NFPs and proposals are allocated in a round-robin fashion. Artifacts include an `nfp` field in `proposals.jsonl`, `metrics.csv`, and in `boundaries.jsonl` (when packing submissions with `--top-k`).
 - Geometry guard: `--guard-geom-validate` pre-screens invalid shapes and logs
   `fail_reason=invalid_geometry` without spending evaluator calls.
    - Thresholds can be tuned: `--guard-r0-min`, `--guard-r0-max`, and
      `--guard-helical-ratio-max`.
+
+ 
  - PCFM correction (examples):
    - Norm equality: constrain helical amplitude to a circle of radius 0.06
      - JSON: `examples/pcfm_norm.json`
      - Run: `constelx agent run --nfp 3 --budget 4 --correction pcfm --constraints-file examples/pcfm_norm.json`
-   - Ratio equality: enforce `z_sin[1][5] / r_cos[1][5] = -1.25`
+  - Ratio equality: enforce `z_sin[1][5] / r_cos[1][5] = -1.25`
      - JSON: `examples/pcfm_ratio.json`
      - Run: `constelx agent run --nfp 3 --budget 4 --correction pcfm --constraints-file examples/pcfm_ratio.json`
    - Product equality: enforce `r_cos[1][5] * z_sin[1][5] = 0.003`
      - JSON: `examples/pcfm_product.json`
      - Run: `constelx agent run --nfp 3 --budget 4 --correction pcfm --constraints-file examples/pcfm_product.json`
   - Tuning: `--pcfm-gn-iters 3 --pcfm-damping 1e-6 --pcfm-tol 1e-8` or via top-level keys in the constraints JSON: `{gn_iters,damping,tol}`
+
+Upcoming (tracked)
+- Surrogate screening in the agent to pre-filter proposals before proxy/real evals (#73).
+- ResultsDB novelty gating to skip near-duplicate proposals (#74).
 
 Multi-fidelity gating
 - Enable a cheap proxy pass before real evaluations to reduce expensive calls:
@@ -100,6 +109,16 @@ Submission
  - Include the top-K boundaries by aggregate score:
    `constelx submit pack runs/<ts> --out submissions/run_<ts>.zip --top-k 5`
    This adds `boundaries.jsonl` with records of the form `{iteration,index,agg_score,evaluator_score,feasible,fail_reason,source,scoring_version,boundary}`.
+
+Ablation
+- Quick component ablations: `constelx ablate run --nfp 3 --budget 6 --components guard_simple,mf_proxy`
+  - Also supports `correction=eci_linear` and `correction=pcfm` toggles (uses simple defaults).
+  - Writes a timestamped folder under `runs/ablations/` with per-variant subfolders and `summary.csv`/`summary.json` at the root.
+ - Spec-driven plan with multi-seed aggregation:
+   - Create `plan.json`:
+     `{ "base": {"nfp":3, "budget":3}, "seeds": [0,1], "variants": [{"name":"baseline","overrides":{}},{"name":"eci_linear","overrides":{"correction":"eci_linear","constraints":[{"rhs":0.0,"coeffs":[{"field":"r_cos","i":1,"j":5,"c":1.0},{"field":"z_sin","i":1,"j":5,"c":1.0}]}]}}] }`
+   - Run: `constelx ablate run --spec plan.json --runs-dir runs/ablations`
+   - Produces `details.csv` (per-variant/seed) and `summary.csv` (best and mean agg_score per variant).
 
 ## Development
 
@@ -163,7 +182,7 @@ The CLI and evaluator auto-load a local `.env` if `python-dotenv` is installed (
 - `CONSTELX_REAL_BACKOFF`: multiplicative backoff factor between retries (default `1.5`).
 
 Artifacts now include clear scoring and provenance fields:
-- CSV: `evaluator_score`, `agg_score`, `elapsed_ms`, `feasible`, `fail_reason`, `source`.
+- CSV: `nfp`, `evaluator_score`, `agg_score`, `elapsed_ms`, `feasible`, `fail_reason`, `source`.
 - `best.json`: `agg_score`, optional `evaluator_score`, and metrics without a conflicting `score` key.
 
 ## Citing

--- a/src/constelx/agents/ablation.py
+++ b/src/constelx/agents/ablation.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+# ruff: noqa: I001  (import-sorting suppressed to match local style)
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from .simple_agent import AgentConfig, run as run_agent
+
+
+@dataclass(frozen=True)
+class AblationResult:
+    name: str
+    best_score: float
+    run_dir: Path
+
+
+def _now_ts() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def _read_best_score(run_dir: Path) -> float:
+    best_path = run_dir / "best.json"
+    try:
+        payload = json.loads(best_path.read_text())
+        if isinstance(payload, dict):
+            if isinstance(payload.get("agg_score"), (int, float)):
+                return float(payload["agg_score"])
+            if isinstance(payload.get("score"), (int, float)):
+                return float(payload["score"])
+    except Exception:
+        pass
+    return float("inf")
+
+
+def _ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def run_ablation(
+    *,
+    base: AgentConfig,
+    components: Iterable[str],
+    out_root: Path,
+) -> List[AblationResult]:
+    """Run a simple ablation study over selected pipeline components.
+
+    For each component name in `components`, toggles that single component on
+    (relative to the provided `base` config), runs the agent with a small
+    budget, and records the best aggregate score. A baseline run is always
+    executed first using the unmodified base config.
+
+    Results are written under `out_root/<timestamp>/` with subfolders
+    `baseline/` and one folder per component name.
+    """
+
+    ts_root = out_root / _now_ts()
+    _ensure_dir(ts_root)
+
+    results: List[AblationResult] = []
+
+    # Baseline
+    base_dir = ts_root / "baseline"
+    _ensure_dir(base_dir)
+    # Force writing into our folder by using resume path
+    run_agent(
+        AgentConfig(
+            nfp=base.nfp,
+            seed=base.seed,
+            out_dir=ts_root,
+            algo=base.algo,
+            budget=base.budget,
+            resume=base_dir,
+            max_workers=base.max_workers,
+            cache_dir=base.cache_dir,
+            correction=base.correction,
+            constraints=base.constraints,
+            use_physics=base.use_physics,
+            problem=base.problem,
+            init_seeds=base.init_seeds,
+            guard_simple=base.guard_simple,
+            guard_geo=base.guard_geo,
+            guard_geom_validate=base.guard_geom_validate,
+            guard_geom_r0_min=base.guard_geom_r0_min,
+            guard_geom_r0_max=base.guard_geom_r0_max,
+            guard_geom_helical_ratio_max=base.guard_geom_helical_ratio_max,
+            mf_proxy=base.mf_proxy,
+            mf_threshold=base.mf_threshold,
+            mf_quantile=base.mf_quantile,
+            mf_max_high=base.mf_max_high,
+            pcfm_gn_iters=base.pcfm_gn_iters,
+            pcfm_damping=base.pcfm_damping,
+            pcfm_tol=base.pcfm_tol,
+        )
+    )
+    results.append(
+        AblationResult(name="baseline", best_score=_read_best_score(base_dir), run_dir=base_dir)
+    )
+
+    # Component-specific toggles
+    for comp in components:
+        name = str(comp).strip().lower()
+        if not name:
+            continue
+        comp_dir = ts_root / name
+        _ensure_dir(comp_dir)
+        cfg = AgentConfig(
+            nfp=base.nfp,
+            seed=base.seed,
+            out_dir=ts_root,
+            algo=base.algo,
+            budget=base.budget,
+            resume=comp_dir,
+            max_workers=base.max_workers,
+            cache_dir=base.cache_dir,
+            correction=base.correction,
+            constraints=base.constraints,
+            use_physics=base.use_physics,
+            problem=base.problem,
+            init_seeds=base.init_seeds,
+            guard_simple=base.guard_simple,
+            guard_geo=base.guard_geo,
+            guard_geom_validate=base.guard_geom_validate,
+            guard_geom_r0_min=base.guard_geom_r0_min,
+            guard_geom_r0_max=base.guard_geom_r0_max,
+            guard_geom_helical_ratio_max=base.guard_geom_helical_ratio_max,
+            mf_proxy=base.mf_proxy,
+            mf_threshold=base.mf_threshold,
+            mf_quantile=base.mf_quantile,
+            mf_max_high=base.mf_max_high,
+            pcfm_gn_iters=base.pcfm_gn_iters,
+            pcfm_damping=base.pcfm_damping,
+            pcfm_tol=base.pcfm_tol,
+        )
+
+        # Apply a single-component toggle
+        if name in {"guard_simple", "guard-simple"}:
+            cfg = AgentConfig(**{**cfg.__dict__, "guard_simple": True})
+        elif name in {"guard_geo", "guard-geo"}:
+            cfg = AgentConfig(**{**cfg.__dict__, "guard_geo": True})
+        elif name in {"guard_geom_validate", "guard-geom-validate"}:
+            cfg = AgentConfig(**{**cfg.__dict__, "guard_geom_validate": True})
+        elif name.startswith("mf_proxy") or name.startswith("mf-proxy"):
+            # Enable proxy with a reasonable keep quantile for quick runs
+            # Support forms: "mf_proxy", "mf_proxy=q:0.5", "mf_proxy=t:0.1"
+            mf_threshold: Optional[float] = None
+            mf_quantile: Optional[float] = 0.5
+            if "=" in name and ":" in name:
+                try:
+                    mode, val = name.split("=", 1)[1].split(":", 1)
+                    if mode in {"q", "quantile"}:
+                        mf_quantile = float(val)
+                        mf_threshold = None
+                    elif mode in {"t", "thresh", "threshold"}:
+                        mf_threshold = float(val)
+                        mf_quantile = None
+                except Exception:
+                    pass
+            cfg = AgentConfig(
+                **{
+                    **cfg.__dict__,
+                    "mf_proxy": True,
+                    "mf_threshold": mf_threshold,
+                    "mf_quantile": mf_quantile,
+                }
+            )
+        elif name in {"algo=cmaes", "algo:cmaes", "cmaes"}:
+            cfg = AgentConfig(**{**cfg.__dict__, "algo": "cmaes"})
+        elif name.startswith("algo=") or name.startswith("algo:"):
+            # Allow generic algo toggles for future additions
+            try:
+                algo_val = name.split("=", 1)[1] if "=" in name else name.split(":", 1)[1]
+                cfg = AgentConfig(**{**cfg.__dict__, "algo": str(algo_val)})
+            except Exception:
+                pass
+        elif name in {"correction=eci_linear", "correction:eci_linear", "eci_linear"}:
+            # Default simple equality: r_cos[1][5] + z_sin[1][5] = 0
+            cfg = AgentConfig(
+                **{
+                    **cfg.__dict__,
+                    "correction": "eci_linear",
+                    "constraints": [
+                        {
+                            "rhs": 0.0,
+                            "coeffs": [
+                                {"field": "r_cos", "i": 1, "j": 5, "c": 1.0},
+                                {"field": "z_sin", "i": 1, "j": 5, "c": 1.0},
+                            ],
+                        }
+                    ],
+                }
+            )
+        elif name in {"correction=pcfm", "correction:pcfm", "pcfm"}:
+            # Default norm equality on (r_cos[1][5], z_sin[1][5]) radius=0.06
+            cfg = AgentConfig(
+                **{
+                    **cfg.__dict__,
+                    "correction": "pcfm",
+                    "constraints": [
+                        {
+                            "type": "norm_eq",
+                            "radius": 0.06,
+                            "terms": [
+                                {"field": "r_cos", "i": 1, "j": 5, "w": 1.0},
+                                {"field": "z_sin", "i": 1, "j": 5, "w": 1.0},
+                            ],
+                        }
+                    ],
+                }
+            )
+        else:
+            # Unknown component: run baseline settings but record name
+            pass
+
+        run_agent(cfg)
+        results.append(
+            AblationResult(name=name, best_score=_read_best_score(comp_dir), run_dir=comp_dir)
+        )
+
+    # Write a compact summary at the root timestamp folder
+    summary_rows = [
+        {"name": r.name, "best_score": r.best_score, "run_dir": str(r.run_dir)} for r in results
+    ]
+    (ts_root / "summary.json").write_text(json.dumps(summary_rows, indent=2))
+    # CSV is optional; keep columns minimal and stable
+    lines = ["name,best_score,run_dir"]
+    for r in results:
+        lines.append(f"{r.name},{r.best_score},{r.run_dir}")
+    (ts_root / "summary.csv").write_text("\n".join(lines) + "\n")
+
+    return results
+
+
+# -------------------- Spec-driven multi-seed ablation --------------------
+
+
+@dataclass(frozen=True)
+class PlanVariant:
+    name: str
+    overrides: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class AblationPlan:
+    base: Mapping[str, Any]
+    seeds: Iterable[int]
+    variants: Iterable[PlanVariant]
+
+
+def _read_best_json(run_dir: Path) -> float:
+    best_path = run_dir / "best.json"
+    try:
+        payload = json.loads(best_path.read_text())
+        if isinstance(payload, dict):
+            if isinstance(payload.get("agg_score"), (int, float)):
+                return float(payload["agg_score"])
+            if isinstance(payload.get("score"), (int, float)):
+                return float(payload["score"])
+    except Exception:
+        pass
+    return float("inf")
+
+
+def run_ablation_plan(*, plan: AblationPlan, out_root: Path) -> Path:
+    """Run an explicit multi-seed, multi-variant ablation plan.
+
+    Plan schema (JSON-friendly):
+      {"base": {...}, "seeds": [0,1], "variants": [{"name": "v1", "overrides": {...}}, ...]}
+
+    Behavior:
+      - Creates a timestamped root under out_root
+      - For each variant and seed, runs the agent in a dedicated subfolder
+        root/variant/seed_<k>/ using resume to force placement.
+      - Writes details.csv (variant,seed,best_agg_score,run_dir) and
+        summary.csv (variant,best_agg_score,mean_agg_score) at the root.
+    """
+    ts_root = out_root / _now_ts()
+    _ensure_dir(ts_root)
+
+    base_map: Dict[str, Any] = dict(plan.base)
+    # Normalize required fields; minimal base fallback
+    if "nfp" not in base_map:
+        base_map["nfp"] = 3
+    if "budget" not in base_map:
+        base_map["budget"] = 4
+    # We always control physical location via resume below
+    base_map.setdefault("algo", "random")
+
+    # Persist plan for reproducibility
+    plan_json = {
+        "base": base_map,
+        "seeds": list(int(s) for s in plan.seeds),
+        "variants": [{"name": v.name, "overrides": dict(v.overrides)} for v in plan.variants],
+    }
+    (ts_root / "plan.json").write_text(json.dumps(plan_json, indent=2))
+
+    # Collect details
+    details_rows: List[Mapping[str, Any]] = []
+    for variant in plan.variants:
+        vdir = ts_root / str(variant.name)
+        _ensure_dir(vdir)
+        for sd in plan.seeds:
+            sdir = vdir / f"seed_{int(sd)}"
+            _ensure_dir(sdir)
+            cfg_map: Dict[str, Any] = dict(base_map)
+            cfg_map.update({"seed": int(sd)})
+            cfg_map.update({k: v for k, v in variant.overrides.items()})
+
+            cfg = AgentConfig(
+                nfp=int(cfg_map.get("nfp", 3)),
+                seed=int(cfg_map.get("seed", 0)),
+                out_dir=ts_root,  # ignored when resume set
+                algo=str(cfg_map.get("algo", "random")),
+                budget=int(cfg_map.get("budget", 4)),
+                resume=sdir,
+                max_workers=int(cfg_map.get("max_workers", 1)),
+                cache_dir=(Path(cfg_map["cache_dir"]) if cfg_map.get("cache_dir") else None),
+                correction=(str(cfg_map["correction"]) if cfg_map.get("correction") else None),
+                constraints=(
+                    list(cfg_map["constraints"])
+                    if isinstance(cfg_map.get("constraints"), list)
+                    else None
+                ),
+                use_physics=bool(cfg_map.get("use_physics", False)),
+                pcfm_gn_iters=(
+                    int(cfg_map["pcfm_gn_iters"])
+                    if cfg_map.get("pcfm_gn_iters") is not None
+                    else None
+                ),
+                pcfm_damping=(
+                    float(cfg_map["pcfm_damping"])
+                    if cfg_map.get("pcfm_damping") is not None
+                    else None
+                ),
+                pcfm_tol=(
+                    float(cfg_map["pcfm_tol"]) if cfg_map.get("pcfm_tol") is not None else None
+                ),
+                problem=(str(cfg_map["problem"]) if cfg_map.get("problem") else None),
+                init_seeds=(Path(cfg_map["init_seeds"]) if cfg_map.get("init_seeds") else None),
+                guard_simple=bool(cfg_map.get("guard_simple", False)),
+                guard_geo=bool(cfg_map.get("guard_geo", False)),
+                guard_geom_validate=bool(cfg_map.get("guard_geom_validate", False)),
+                guard_geom_r0_min=float(cfg_map.get("guard_geom_r0_min", 0.05)),
+                guard_geom_r0_max=float(cfg_map.get("guard_geom_r0_max", 5.0)),
+                guard_geom_helical_ratio_max=float(
+                    cfg_map.get("guard_geom_helical_ratio_max", 0.5)
+                ),
+                mf_proxy=bool(cfg_map.get("mf_proxy", False)),
+                mf_threshold=(
+                    float(cfg_map["mf_threshold"])
+                    if cfg_map.get("mf_threshold") is not None
+                    else None
+                ),
+                mf_quantile=(
+                    float(cfg_map["mf_quantile"])
+                    if cfg_map.get("mf_quantile") is not None
+                    else None
+                ),
+                mf_max_high=(
+                    int(cfg_map["mf_max_high"]) if cfg_map.get("mf_max_high") is not None else None
+                ),
+            )
+
+            run_agent(cfg)
+            best = _read_best_json(sdir)
+            details_rows.append(
+                {
+                    "variant": variant.name,
+                    "seed": int(sd),
+                    "best_agg_score": best,
+                    "run_dir": str(sdir),
+                }
+            )
+
+    # Write details.csv and summary.csv/json
+    import csv
+
+    with (ts_root / "details.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["variant", "seed", "best_agg_score", "run_dir"])
+        w.writeheader()
+        for r in details_rows:
+            w.writerow(r)
+
+    # Aggregate per variant
+    from math import inf
+
+    by_variant: Dict[str, List[float]] = {}
+    for r in details_rows:
+        by_variant.setdefault(str(r["variant"]), []).append(float(r["best_agg_score"]))
+    summary_rows: List[Mapping[str, Any]] = []
+    for name, vals in by_variant.items():
+        if vals:
+            best = min(vals)
+            mean = sum(vals) / len(vals)
+        else:
+            best, mean = inf, inf
+        summary_rows.append({"variant": name, "best_agg_score": best, "mean_agg_score": mean})
+    summary_rows.sort(key=lambda x: x["variant"])  
+
+    with (ts_root / "summary.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["variant", "best_agg_score", "mean_agg_score"])
+        w.writeheader()
+        for r in summary_rows:
+            w.writerow(r)
+    (ts_root / "summary.json").write_text(json.dumps(summary_rows, indent=2))
+
+    return ts_root

--- a/src/constelx/cli.py
+++ b/src/constelx/cli.py
@@ -146,9 +146,7 @@ def eval_forward(
     json_out: bool = typer.Option(False, "--json", help="Emit raw JSON metrics."),
 ) -> None:
     if sum([bool(example), boundary_json is not None, bool(random_boundary)]) != 1:
-        raise typer.BadParameter(
-            "Choose exactly one of --example, --boundary-json, or --random"
-        )
+        raise typer.BadParameter("Choose exactly one of --example, --boundary-json, or --random")
 
     if example:
         from .physics.constel_api import example_boundary
@@ -156,6 +154,7 @@ def eval_forward(
         b = example_boundary()
     elif random_boundary:
         from .eval.boundary_param import sample_random, validate as validate_boundary
+
         b = sample_random(nfp=nfp, seed=seed)
         validate_boundary(b)
     else:

--- a/src/constelx/submit/pack.py
+++ b/src/constelx/submit/pack.py
@@ -211,6 +211,10 @@ def pack_run(run_dir: Path, out_path: Path, top_k: int = 1) -> Path:
                     rec = {
                         "iteration": row.get("iteration"),
                         "index": row.get("index"),
+                        "nfp": row.get(
+                            "nfp",
+                            bnd.get("n_field_periods") if isinstance(bnd, dict) else None,
+                        ),
                         "agg_score": row.get("agg_score"),
                         "evaluator_score": row.get("evaluator_score"),
                         "feasible": row.get("feasible"),

--- a/tests/test_cli_ablate.py
+++ b/tests/test_cli_ablate.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_cli_ablate_quick_components(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runs_dir = tmp_path / "ablations"
+    # Include a correction toggle to exercise constraint wiring
+    result = runner.invoke(
+        app,
+        [
+            "ablate",
+            "run",
+            "--nfp",
+            "3",
+            "--budget",
+            "3",
+            "--seed",
+            "0",
+            "--runs-dir",
+            str(runs_dir),
+            "--components",
+            "guard_simple,mf_proxy,correction=eci_linear",
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Find the timestamped ablation folder and summary
+    roots = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert len(roots) == 1
+    root = roots[0]
+    summary_csv = root / "summary.csv"
+    assert summary_csv.exists()
+    content = summary_csv.read_text()
+    # minimal presence checks
+    assert "baseline" in content
+    assert "guard_simple" in content
+    assert "mf_proxy" in content
+    assert "correction=eci_linear" in content or "eci_linear" in content
+

--- a/tests/test_cli_ablate_spec.py
+++ b/tests/test_cli_ablate_spec.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_cli_ablate_spec_plan(tmp_path: Path) -> None:
+    # Build a tiny spec with two variants and two seeds
+    spec = {
+        "base": {"nfp": 3, "budget": 3},
+        "seeds": [0, 1],
+        "variants": [
+            {"name": "baseline", "overrides": {}},
+            {
+                "name": "eci_linear",
+                "overrides": {
+                    "correction": "eci_linear",
+                    "constraints": [
+                        {
+                            "rhs": 0.0,
+                            "coeffs": [
+                                {"field": "r_cos", "i": 1, "j": 5, "c": 1.0},
+                                {"field": "z_sin", "i": 1, "j": 5, "c": 1.0},
+                            ],
+                        }
+                    ],
+                },
+            },
+        ],
+    }
+    spec_path = tmp_path / "plan.json"
+    spec_path.write_text(json.dumps(spec))
+
+    runs_dir = tmp_path / "ablations"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "ablate",
+            "run",
+            "--spec",
+            str(spec_path),
+            "--runs-dir",
+            str(runs_dir),
+        ],
+    )
+    assert result.exit_code == 0
+
+    roots = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert len(roots) == 1
+    root = roots[0]
+    details = root / "details.csv"
+    summary = root / "summary.csv"
+    assert details.exists() and summary.exists()
+    content = summary.read_text()
+    assert "baseline" in content and "eci_linear" in content
+

--- a/tests/test_cli_agent_nfp_list.py
+++ b/tests/test_cli_agent_nfp_list.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_agent_nfp_list_round_robin_and_provenance(tmp_path: Path) -> None:
+    runner = CliRunner()
+    runs_dir = tmp_path / "runs"
+    res = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--nfp-list",
+            "3,4",
+            "--budget",
+            "4",
+            "--seed",
+            "0",
+            "--runs-dir",
+            str(runs_dir),
+        ],
+    )
+    assert res.exit_code == 0
+
+    # Locate the run folder and read artifacts
+    subdirs = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert subdirs, "no run directory created"
+    out = subdirs[0]
+
+    # Check proposals.jsonl contains an nfp field in round-robin order
+    props_lines = (out / "proposals.jsonl").read_text().splitlines()
+    assert len(props_lines) == 4
+    props_nfp = [json.loads(line).get("nfp") for line in props_lines]
+    assert props_nfp == [3, 4, 3, 4]
+
+    # Check metrics.csv has an nfp column with the same order
+    rows = list(csv.DictReader((out / "metrics.csv").open()))
+    assert rows, "metrics.csv should have rows"
+    assert "nfp" in rows[0], "missing nfp column in metrics.csv"
+    nfp_vals = [int(r["nfp"]) for r in rows]
+    assert nfp_vals == [3, 4, 3, 4]
+


### PR DESCRIPTION
Summary
- Adds a lightweight ablation harness and `constelx ablate run` subcommand. Supports quick one-at-a-time component toggles and explicit multi-seed, multi-variant plans via `--spec`.

Motivation
- Implements TODO #53 to enable fast, reproducible comparisons across guards, proxy gating, correction hooks, and algorithm choices with small budgets.

Behavior and Artifacts
- Toggle mode:
  - Runs baseline plus one run per component under `runs/ablations/<ts>/`
  - Writes `summary.csv` and `summary.json` with best scores and run directories
- Spec mode:
  - `--spec/--spec-file` accepts `{base, seeds, variants[{name, overrides}]}` JSON
  - Writes `plan.json`, `details.csv` (per-variant/seed), and `summary.csv/json` (best and mean agg_score)
  - Per-variant/per-seed subfolders: `<variant>/seed_<k>/`

CLI Examples
- Toggle: `constelx ablate run --nfp 3 --budget 4 --components guard_simple,mf_proxy`
- Spec: `constelx ablate run --spec plan.json --runs-dir runs/ablations`

Tests and Quality
- New CLI tests cover both toggle and spec paths (`tests/test_cli_ablate.py`, `tests/test_cli_ablate_spec.py`)
- Runs fast with placeholder evaluator

Next Steps
- Optional: YAML spec support; per-variant PCFM/guard threshold knobs; additional summary stats (median/std); tiny `examples/ablation_plan_min.json` for docs

Closes #53