### PR TITLE
Near-axis expansion seeding for QS/QI-friendly starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ See `docs/ROADMAP.md` (engineering roadmap) and `docs/STRATEGY.md`
 Evaluation
 - `constelx eval forward --example`
 - `constelx eval forward --random --nfp 3 --seed 0`
+- Near-axis QS/QI-friendly seed: `constelx eval forward --near-axis --nfp 3 --seed 0`
 - `constelx eval score --metrics-json examples/metrics_small.json`
 
 Optimization
@@ -60,6 +61,7 @@ Optimization
 
 Agent
 - Random search: `constelx agent run --nfp 3 --budget 6 --seed 0 --runs-dir runs`
+- Near-axis seeding: `constelx agent run --nfp 3 --budget 6 --seed-mode near-axis`
 - CMA-ES (falls back to random if cma missing):
   `constelx agent run --nfp 3 --budget 20 --algo cmaes --seed 0`
 - Resume a run: `constelx agent run --nfp 3 --budget 10 --resume runs/<ts>`

--- a/tests/test_near_axis_seeding.py
+++ b/tests/test_near_axis_seeding.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from constelx.eval.boundary_param import sample_near_axis_qs, validate
+from constelx.eval.geometry import quick_geometry_validate
+
+
+def test_sample_near_axis_is_deterministic() -> None:
+    b1 = sample_near_axis_qs(nfp=3, seed=123)
+    b2 = sample_near_axis_qs(nfp=3, seed=123)
+    assert b1 == b2
+    validate(b1)
+
+
+def test_near_axis_passes_quick_geometry() -> None:
+    b = sample_near_axis_qs(nfp=3, seed=0, r0=1.0, epsilon=0.06)
+    validate(b)
+    ok, reason = quick_geometry_validate(b, r0_min=0.05, r0_max=5.0, helical_ratio_max=0.5)
+    assert ok, f"near-axis seed should pass quick geometry guard, got: {reason}"


### PR DESCRIPTION
Summary
- Introduces a lightweight, deterministic near-axis-inspired seed generator usage to start runs from QS/QI-friendly boundaries. Adds CLI switches to use it in both eval and agent workflows.

What’s changed
- eval.boundary_param: sample_near_axis_qs is wired into CLI and agent (already present in library).
- CLI: eval forward supports `--near-axis` to generate a seed and run metrics.
- Agent: agent run supports `--seed-mode random|near-axis`; defaults to `random`.
- Tests: determinism and quick geometry guard for near-axis seeds.
- Docs: README usage examples for both new flags.

Why
- Better initialization for QS/QI searches than fully random starts; consistent with near-axis intuition and sign conventions, while remaining fast and dependency-light.

CLI examples
- `constelx eval forward --near-axis --nfp 3 --seed 0`
- `constelx agent run --nfp 3 --budget 6 --seed 0 --seed-mode near-axis`

Tests
- tests/test_near_axis_seeding.py:
  - test_sample_near_axis_is_deterministic
  - test_near_axis_passes_quick_geometry

Performance/behavior
- No heavy near-axis libraries; algebraic construction via BoundaryFourier in eval.boundary_param.
- Deterministic, minimal overhead; default behavior remains identical unless flags are used.

Compatibility
- No breaking changes; AgentConfig gains `seed_mode` with a default.

Closes #47