### PR TITLE
feat: add Boozer QS/QI evaluator bridge (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Notes:
 
 - **CLI (`constelx`)**: `data` (fetch/filter/csv), `eval` (forward metrics, scoring), `opt` (baselines), `surrogate` (train/serve simple models), `agent` (multi-step propose→simulate→select loop).
 - **Physics wrappers**: thin adapters around the `constellaration` package for metrics and VMEC++ boundary objects, plus bounded Boozer-space QS/QI proxies (`constelx.physics.booz_proxy`).
+- **Proxy metrics**: Boozer-space quasi-symmetry/isodynamic proxies with bounded residuals (`constelx.eval.boozer`). Placeholder + real evaluator paths populate `proxy_qs_*` / `proxy_qi_*` fields for early-stage guards.
 - **Optimization**: CMA-ES and (optional) BoTorch Bayesian optimization stubs.
 - **Models**: simple MLP baseline + placeholders for FNO/transformers.
 - **Hard-constraint tooling**: PCFM projection helpers and a PBFM conflict-free gradient update for physics-aware generation and training.

--- a/docs/GUIDELINE.md
+++ b/docs/GUIDELINE.md
@@ -8,7 +8,7 @@ Scoring formalism. Single‑objective problems map to a bounded score s(\Theta)\
 
 What you’re given. The HF dataset contains plasma boundaries (Fourier coefficients), equilibria (“wout”) and metrics; the constellaration Python package (PyPI/GitHub) includes evaluation functions, forward‑model wrappers, and submission helpers. VMEC++ is an open‑source, modernized VMEC with a Python‑first interface. ￼ ￼
 
-Useful physics background: stage‑1 optimizes a Fourier boundary in R(\theta,\phi),Z(\theta,\phi); quasi‑symmetry / quasi‑isodynamic metrics are naturally defined in Boozer coordinates; coil simplicity proxies and MHD/turbulence proxies are standard “stage‑1” surrogates. ￼
+Useful physics background: stage-1 optimizes a Fourier boundary in R(\theta,\phi),Z(\theta,\phi); quasi-symmetry / quasi-isodynamic metrics are naturally defined in Boozer coordinates; coil simplicity proxies and MHD/turbulence proxies are standard “stage-1” surrogates. ￼ Implementation tip: `constelx.eval.boozer.compute_boozer_proxies` exposes bounded QS/QI residuals and mirror-ratio proxies so guardrails can run before paying for full VMEC++ solves.
 
 ⸻
 

--- a/src/constelx/eval/boozer.py
+++ b/src/constelx/eval/boozer.py
@@ -1,0 +1,201 @@
+"""Boozer-space quasi-symmetry and quasi-isodynamic proxy metrics.
+
+This module offers a lightweight, dependency-free (besides NumPy) implementation of
+proxy observables that correlate with quasi-symmetry (QS) and quasi-isodynamic (QI)
+quality. The proxies intentionally avoid heavy Boozer transforms by operating on the
+existing truncated Fourier representation of stellarator-symmetric boundaries.
+
+The design goals are:
+- Deterministic, cheap to evaluate (O(m n n_theta n_phi))
+- Bounded residuals in [0, 1] so that downstream constraint handlers can rely on
+  consistent scales
+- Simple to integrate into guardrails or proxy-evaluation paths before the real
+  evaluator is available
+
+Example
+-------
+>>> from constelx.physics.constel_api import example_boundary
+>>> proxies = compute_boozer_proxies(example_boundary())
+>>> proxies.qs_residual <= 1.0
+True
+>>> proxies.to_dict(prefix="proxy_")  # doctest: +ELLIPSIS
+{'proxy_b_mean': ..., 'proxy_b_std_fraction': ..., ...}
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from .boundary_fourier import BoundaryFourier
+
+__all__ = ["BoozerProxies", "compute_boozer_proxies"]
+
+_EPS = 1e-12
+
+
+def _bounded_ratio(value: float) -> float:
+    """Map a non-negative value to [0, 1) using ``x -> x / (1 + x)``."""
+    v = max(0.0, float(value))
+    return v / (1.0 + v)
+
+
+@dataclass(frozen=True)
+class BoozerProxies:
+    """Container for Boozer-derived proxy metrics."""
+
+    b_mean: float
+    b_std_fraction: float
+    mirror_ratio: float
+    qs_residual: float
+    qs_quality: float
+    qi_residual: float
+    qi_quality: float
+
+    @staticmethod
+    def zeros() -> "BoozerProxies":
+        """Return a zero-initialized proxy payload."""
+        return BoozerProxies(
+            b_mean=0.0,
+            b_std_fraction=0.0,
+            mirror_ratio=0.0,
+            qs_residual=0.0,
+            qs_quality=1.0,
+            qi_residual=0.0,
+            qi_quality=1.0,
+        )
+
+    def to_dict(self, *, prefix: str | None = None) -> dict[str, float]:
+        """Convert proxies to a dict with optional key prefixing."""
+        data = {
+            "b_mean": float(self.b_mean),
+            "b_std_fraction": float(self.b_std_fraction),
+            "mirror_ratio": float(self.mirror_ratio),
+            "qs_residual": float(self.qs_residual),
+            "qs_quality": float(self.qs_quality),
+            "qi_residual": float(self.qi_residual),
+            "qi_quality": float(self.qi_quality),
+        }
+        if prefix:
+            return {f"{prefix}{k}": v for k, v in data.items()}
+        return data
+
+
+def _angles_for_sampling(n_theta: int, n_phi: int, nfp: int) -> tuple[np.ndarray, np.ndarray]:
+    thetas = np.linspace(0.0, 2.0 * math.pi, num=n_theta, endpoint=False, dtype=float)
+    # Toroidal angle spans one field period (2π / nfp)
+    phis = np.linspace(0.0, 2.0 * math.pi / max(1, nfp), num=n_phi, endpoint=False, dtype=float)
+    return thetas, phis
+
+
+def _sample_surface_arrays(
+    bf: BoundaryFourier, thetas: np.ndarray, phis: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return (R, Z) arrays sampled on the theta/phi grid."""
+    theta_grid, phi_grid = np.meshgrid(thetas, phis, indexing="ij")
+    R = np.zeros_like(theta_grid, dtype=float)
+    Z = np.zeros_like(theta_grid, dtype=float)
+
+    for m in range(bf.m_dim):
+        m_theta = m * theta_grid
+        for j in range(bf.n_dim):
+            n = j - bf.n_offset
+            phase = m_theta - n * phi_grid
+            a = float(bf.r_cos[m][j])
+            b = float(bf.z_sin[m][j])
+            if a != 0.0:
+                R += a * np.cos(phase)
+            if b != 0.0:
+                Z += b * np.sin(phase)
+    return R, Z
+
+
+def compute_boozer_proxies(
+    boundary: Mapping[str, Any],
+    *,
+    helicity: int | None = None,
+    n_theta: int = 24,
+    n_phi: int = 24,
+) -> BoozerProxies:
+    """Compute Boozer-space proxy metrics from a boundary description.
+
+    Parameters
+    ----------
+    boundary:
+        Mapping compatible with ``SurfaceRZFourier`` (requires ``r_cos`` and ``z_sin`` fields).
+    helicity:
+        Integer Boozer helicity ``N`` for the quasi-symmetry residual. Defaults to
+        ``boundary['n_field_periods']``.
+    n_theta, n_phi:
+        Sampling resolution for the coarse grid used to evaluate the proxies.
+
+    Returns
+    -------
+    BoozerProxies
+        Container with bounded residuals and quality scores.
+    """
+
+    try:
+        bf = BoundaryFourier.from_surface_dict(dict(boundary))
+    except Exception:
+        return BoozerProxies.zeros()
+
+    if n_theta <= 4 or n_phi <= 4:
+        raise ValueError("n_theta and n_phi must be >= 5 for meaningful sampling")
+
+    thetas, phis = _angles_for_sampling(int(n_theta), int(n_phi), bf.nfp)
+    R, _ = _sample_surface_arrays(bf, thetas, phis)
+
+    r_mean = float(np.mean(R))
+    if not math.isfinite(r_mean) or abs(r_mean) <= _EPS:
+        return BoozerProxies.zeros()
+
+    B = r_mean / np.clip(np.abs(R), _EPS, None)
+    B_mean = float(np.mean(B))
+    B_std_fraction = _bounded_ratio(float(np.std(B) / (B_mean + _EPS)))
+    B_max = float(np.max(B))
+    B_min = float(np.min(B))
+    mirror_ratio = _bounded_ratio((B_max - B_min) / (B_min + _EPS))
+
+    if helicity is None:
+        helicity = int(boundary.get("n_field_periods", bf.nfp))
+    helicity = int(helicity)
+    theta_grid, phi_grid = np.meshgrid(thetas, phis, indexing="ij")
+    alpha = (theta_grid - helicity * phi_grid) % (2.0 * math.pi)
+    n_bins = max(8, int(n_phi))
+    bin_idx = np.floor(alpha / (2.0 * math.pi) * n_bins).astype(int)
+    bin_idx = np.mod(bin_idx, n_bins)
+
+    flat_bins = bin_idx.ravel()
+    flat_B = B.ravel()
+
+    sums = np.zeros(n_bins, dtype=float)
+    counts = np.zeros(n_bins, dtype=int)
+    np.add.at(sums, flat_bins, flat_B)
+    np.add.at(counts, flat_bins, 1)
+
+    means = np.divide(sums, counts, out=np.zeros_like(sums), where=counts > 0)
+    centered = flat_B - means[flat_bins]
+    qs_rms = math.sqrt(float(np.mean(centered * centered)))
+    qs_res_norm = qs_rms / (B_mean + _EPS)
+    qs_residual = _bounded_ratio(qs_res_norm)
+    qs_quality = 1.0 - qs_residual
+
+    B_min_phi = np.min(B, axis=0)
+    mean_min = float(np.mean(B_min_phi))
+    min_spread = float(np.std(B_min_phi) / (mean_min + _EPS))
+    qi_residual = _bounded_ratio(min_spread)
+    qi_quality = 1.0 - qi_residual
+
+    return BoozerProxies(
+        b_mean=B_mean,
+        b_std_fraction=B_std_fraction,
+        mirror_ratio=mirror_ratio,
+        qs_residual=qs_residual,
+        qs_quality=qs_quality,
+        qi_residual=qi_residual,
+        qi_quality=qi_quality,
+    )

--- a/tests/test_eval_boozer.py
+++ b/tests/test_eval_boozer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from constelx.eval.boozer import compute_boozer_proxies
+from constelx.eval.boundary_fourier import BoundaryFourier
+from constelx.physics.constel_api import evaluate_boundary, example_boundary
+
+
+def test_boozer_proxies_bounded() -> None:
+    proxies = compute_boozer_proxies(example_boundary())
+    assert math.isfinite(proxies.b_mean)
+    assert 0.0 <= proxies.b_std_fraction <= 1.0
+    assert 0.0 <= proxies.mirror_ratio <= 1.0
+    assert 0.0 <= proxies.qs_residual <= 1.0
+    assert 0.0 <= proxies.qi_residual <= 1.0
+    assert proxies.qs_quality == pytest.approx(1.0 - proxies.qs_residual)
+    assert proxies.qi_quality == pytest.approx(1.0 - proxies.qi_residual)
+
+
+def test_boozer_proxies_prefix_dict() -> None:
+    proxies = compute_boozer_proxies(example_boundary())
+    prefixed = proxies.to_dict(prefix="proxy_")
+    assert all(key.startswith("proxy_") for key in prefixed)
+    assert prefixed["proxy_qs_quality"] == proxies.qs_quality
+
+
+def test_boozer_residuals_respond_to_deformation() -> None:
+    base = example_boundary()
+    base_proxies = compute_boozer_proxies(base)
+
+    bf = BoundaryFourier.from_surface_dict(base)
+    i, j = bf.idx(1, 2)
+    bf.r_cos[i][j] = 0.4  # introduce additional helical content
+    bf.z_sin[i][j] = 0.4
+    distorted = bf.to_surface_rz_fourier_dict()
+    distorted_proxies = compute_boozer_proxies(distorted)
+
+    assert distorted_proxies.qs_residual > base_proxies.qs_residual
+    assert distorted_proxies.qi_residual >= base_proxies.qi_residual
+
+
+def test_evaluate_boundary_adds_proxy_metrics() -> None:
+    metrics = evaluate_boundary(example_boundary(), use_real=False)
+    assert "proxy_qs_residual" in metrics
+    assert "proxy_qi_quality" in metrics


### PR DESCRIPTION
## Summary
- add dedicated Boozer evaluator module that wraps proxy metrics for QS/QI
- thread the new helpers through the CLI and physics API without regressing gating
- refresh docs to explain the QS/QI workflow and expected ranges

## Testing
- pytest tests/test_eval_boozer.py tests/test_eval_mf_gating.py
