### PR TITLE
feat: add data-driven seeds prior pipeline (#45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,11 +160,14 @@ Physics test opt‑in
 ## CLI behavior to implement
 
 - `constelx data fetch --nfp 3 --limit 128`
+- `constelx data prior-train data/cache/subset.jsonl --out models/seeds_prior.joblib`
+- `constelx data prior-sample models/seeds_prior.joblib --count 16 --nfp 3`
 - `constelx eval forward --boundary-file examples/boundary.json`
 - `constelx eval score --metrics-file runs/<ts>/metrics.csv`
 - `constelx opt cmaes --nfp 3 --budget 50 [--seed 0]`
 - `constelx opt run --baseline trust-constr|alm|cmaes --nfp 3 --budget 50 [--seed 0] [--use-physics --problem p1]`
 - `constelx agent run --nfp 3 --budget 50 [--seed 0] [--resume PATH]`
+- Prior seeding: `constelx agent run --nfp 3 --budget 20 --seed-mode prior --seed-prior models/seeds_prior.joblib`
 
 ### New helper flags (already available)
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Notes:
 
 - **CLI (`constelx`)**: `data` (fetch/filter/csv), `eval` (forward metrics, scoring), `opt` (baselines), `surrogate` (train/serve simple models), `agent` (multi-step propose→simulate→select loop).
 - **Physics wrappers**: thin adapters around the `constellaration` package for metrics and VMEC++ boundary objects, plus bounded Boozer-space QS/QI proxies (`constelx.physics.booz_proxy`).
+- **Proxy metrics**: Boozer-space quasi-symmetry/isodynamic proxies with bounded residuals (`constelx.eval.boozer`). Placeholder + real evaluator paths populate `proxy_qs_*` / `proxy_qi_*` fields for early-stage guards.
 - **Optimization**: CMA-ES and (optional) BoTorch Bayesian optimization stubs.
 - **Models**: simple MLP baseline + placeholders for FNO/transformers.
 - **Hard-constraint tooling**: PCFM projection helpers and a PBFM conflict-free gradient update for physics-aware generation and training.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ constelx --help
 constelx data fetch --nfp 3 --limit 32
 constelx eval forward --example  # runs an example boundary through metrics
 constelx eval forward --random --nfp 3 --seed 0
+constelx data prior-train data/dataset.jsonl --out models/seeds_prior.joblib
+constelx data prior-sample models/seeds_prior.joblib --count 16 --nfp 3 --min-feasibility 0.3
 ```
 
 Notes:
@@ -73,6 +75,7 @@ Optimization baselines (trust‑constr / ALM)
 Agent
 - Random search: `constelx agent run --nfp 3 --budget 6 --seed 0 --runs-dir runs`
 - Near-axis seeding: `constelx agent run --nfp 3 --budget 6 --seed-mode near-axis`
+- Data prior seeding: `constelx agent run --nfp 3 --budget 10 --seed-mode prior --seed-prior models/seeds_prior.joblib`
 - CMA-ES (falls back to random if cma missing):
   `constelx agent run --nfp 3 --budget 20 --algo cmaes --seed 0`
 - Resume a run: `constelx agent run --nfp 3 --budget 10 --resume runs/<ts>`

--- a/docs/GUIDELINE.md
+++ b/docs/GUIDELINE.md
@@ -8,7 +8,7 @@ Scoring formalism. Single‑objective problems map to a bounded score s(\Theta)\
 
 What you’re given. The HF dataset contains plasma boundaries (Fourier coefficients), equilibria (“wout”) and metrics; the constellaration Python package (PyPI/GitHub) includes evaluation functions, forward‑model wrappers, and submission helpers. VMEC++ is an open‑source, modernized VMEC with a Python‑first interface. ￼ ￼
 
-Useful physics background: stage‑1 optimizes a Fourier boundary in R(\theta,\phi),Z(\theta,\phi); quasi‑symmetry / quasi‑isodynamic metrics are naturally defined in Boozer coordinates; coil simplicity proxies and MHD/turbulence proxies are standard “stage‑1” surrogates. ￼
+Useful physics background: stage-1 optimizes a Fourier boundary in R(\theta,\phi),Z(\theta,\phi); quasi-symmetry / quasi-isodynamic metrics are naturally defined in Boozer coordinates; coil simplicity proxies and MHD/turbulence proxies are standard “stage-1” surrogates. ￼ Implementation tip: `constelx.eval.boozer.compute_boozer_proxies` exposes bounded QS/QI residuals and mirror-ratio proxies so guardrails can run before paying for full VMEC++ solves.
 
 ⸻
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "scipy>=1.11",
   "pandas>=2.0",
   "datasets>=2.20",
+  "scikit-learn>=1.5",
   "rich>=13.7",
   "typer>=0.12",
   "pydantic>=2.7",

--- a/src/constelx/agents/simple_agent.py
+++ b/src/constelx/agents/simple_agent.py
@@ -1271,8 +1271,6 @@ def run(config: AgentConfig) -> Path:
                     metrics = {}
                     s = float("inf")
                 _t1 = time.perf_counter()
-                    s = float("inf")
-                _t1 = time.perf_counter()
                 if isinstance(metrics, dict):
                     metrics.setdefault("source", source_tag)
                     metrics.setdefault("seed_source", source_tag)

--- a/src/constelx/data/__init__.py
+++ b/src/constelx/data/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
 from .results_db import ResultsDB
+from .seeds_prior import (
+    FeasibilitySpec,
+    SeedsPriorConfig,
+    SeedsPriorModel,
+    train_prior,
+)
 
-__all__ = ["ResultsDB"]
+__all__ = [
+    "ResultsDB",
+    "FeasibilitySpec",
+    "SeedsPriorConfig",
+    "SeedsPriorModel",
+    "train_prior",
+]

--- a/src/constelx/data/seeds_prior.py
+++ b/src/constelx/data/seeds_prior.py
@@ -1,0 +1,571 @@
+"""Data-driven seeds prior using PCA + RF + generative models.
+
+This module implements a lightweight training pipeline that mirrors the
+ConStellaration paper's data prior: flatten boundary Fourier coefficients,
+compress them with PCA, learn a random forest feasibility classifier, and fit
+a generative model (Gaussian mixture or a simple quantile-based normalizing
+flow) on the feasible latent manifold. The resulting model can score new
+boundaries for feasibility and sample synthetic seeds for the agent.
+
+Typical usage::
+
+    from constelx.data.seeds_prior import (
+        FeasibilitySpec,
+        SeedsPriorConfig,
+        train_prior,
+    )
+
+    model = train_prior(records, SeedsPriorConfig(), FeasibilitySpec())
+    samples = model.sample(count=8, nfp=3, min_feasibility=0.6, seed=0)
+    for s in samples:
+        boundary = s.boundary
+        prob = s.feasibility_score
+        # feed to constelx.agent or write to seeds.jsonl
+
+The module is intentionally self-contained so CLI commands and tests can reuse
+the same training utilities without duplicating feature extraction logic.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import joblib
+import numpy as np
+from numpy.typing import NDArray
+from scipy.stats import norm
+from sklearn.decomposition import PCA
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.mixture import GaussianMixture
+from sklearn.preprocessing import QuantileTransformer, StandardScaler
+
+from ..eval.boundary_param import validate as validate_boundary
+
+CoeffArray = List[List[float]]
+
+
+def _ensure_nested_list(values: Optional[Iterable[Iterable[Any]]]) -> Optional[CoeffArray]:
+    if values is None:
+        return None
+    out: CoeffArray = []
+    for row in values:
+        out.append([float(x) for x in row])
+    return out
+
+
+def _nested_get(data: Mapping[str, Any], path: str) -> Any:
+    if path in data:
+        return data[path]
+    current: Any = data
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _round_int(x: float | int, *, default: int = 3) -> int:
+    try:
+        return int(round(float(x)))
+    except Exception:
+        return default
+
+
+def _make_grid(shape: tuple[int, int]) -> CoeffArray:
+    m, n = shape
+    return [[0.0 for _ in range(n)] for _ in range(m)]
+
+
+class BoundaryVectorizer:
+    """Flatten boundary dictionaries into feature vectors and invert them back."""
+
+    def __init__(self) -> None:
+        self.fields: List[str] = []
+        self.m_dim: int = 0
+        self.n_dim: int = 0
+        self.nfp_index: int = 0
+        self._offsets: dict[str, slice] = {}
+        self._total_dim: int = 0
+
+    def fit(self, boundaries: Sequence[Mapping[str, Any]]) -> BoundaryVectorizer:
+        if not boundaries:
+            raise ValueError("At least one boundary is required to fit the vectorizer")
+        fields = ["r_cos", "z_sin"]
+        if any(b.get("r_sin") not in (None, []) for b in boundaries):
+            fields.append("r_sin")
+        if any(b.get("z_cos") not in (None, []) for b in boundaries):
+            fields.append("z_cos")
+        m_dim = 0
+        n_dim = 0
+        for b in boundaries:
+            for fname in fields:
+                arr = b.get(fname)
+                if arr is None:
+                    continue
+                try:
+                    rows = len(arr)
+                    cols = len(arr[0]) if rows > 0 else 0
+                except Exception:
+                    continue
+                m_dim = max(m_dim, rows)
+                n_dim = max(n_dim, cols)
+        if m_dim == 0 or n_dim == 0:
+            # fallback to minimal grid
+            m_dim = max(m_dim, 1)
+            n_dim = max(n_dim, 1)
+        self.fields = fields
+        self.m_dim = m_dim
+        self.n_dim = n_dim
+        offset = 1  # reserve first entry for nfp
+        self.nfp_index = 0
+        self._offsets = {}
+        size = m_dim * n_dim
+        for fname in fields:
+            self._offsets[fname] = slice(offset, offset + size)
+            offset += size
+        self._total_dim = offset
+        return self
+
+    @property
+    def feature_dim(self) -> int:
+        return self._total_dim
+
+    def transform(self, boundary: Mapping[str, Any]) -> NDArray[np.float64]:
+        if not self.fields:
+            raise RuntimeError("BoundaryVectorizer must be fit before calling transform")
+        vec = np.zeros(self._total_dim, dtype=np.float64)
+        vec[self.nfp_index] = float(boundary.get("n_field_periods", 3))
+        for fname in self.fields:
+            arr = boundary.get(fname)
+            buf = np.zeros((self.m_dim, self.n_dim), dtype=np.float64)
+            if arr is not None:
+                try:
+                    for i in range(min(len(arr), self.m_dim)):
+                        row = arr[i]
+                        for j in range(min(len(row), self.n_dim)):
+                            buf[i, j] = float(row[j])
+                except Exception:
+                    pass
+            vec[self._offsets[fname]] = buf.reshape(-1)
+        return vec
+
+    def inverse_transform(
+        self,
+        vec: NDArray[np.float64],
+        *,
+        override_nfp: Optional[int] = None,
+        coeff_abs_max: float = 2.0,
+        base_radius_min: float = 1e-3,
+    ) -> dict[str, Any]:
+        if vec.shape[0] != self._total_dim:
+            raise ValueError(f"Expected vector of length {self._total_dim}, got {vec.shape[0]}")
+        nfp_val = _round_int(vec[self.nfp_index])
+        if override_nfp is not None:
+            nfp_val = int(override_nfp)
+        result: dict[str, Any] = {
+            "n_field_periods": nfp_val,
+            "is_stellarator_symmetric": True,
+        }
+        base_idx = min(4, self.n_dim - 1)
+        for fname in self.fields:
+            sl = self._offsets[fname]
+            arr = vec[sl].reshape((self.m_dim, self.n_dim))
+            arr = np.clip(arr, -coeff_abs_max, coeff_abs_max)
+            if fname == "r_cos":
+                arr[0, base_idx] = float(max(base_radius_min, arr[0, base_idx]))
+            result[fname] = arr.tolist()
+        # Optional fields were included only if seen during fit; keep None otherwise
+        if "r_sin" not in self.fields:
+            result["r_sin"] = None
+        if "z_cos" not in self.fields:
+            result["z_cos"] = None
+        return result
+
+
+@dataclass(frozen=True)
+class FeasibilitySpec:
+    """Describe how to extract feasibility labels from dataset records."""
+
+    field: Optional[str] = "metrics.feasible"
+    metric: Optional[str] = None
+    threshold: Optional[float] = None
+    sense: str = "lt"  # 'lt' (<= threshold) or 'gt' (>= threshold)
+
+    def evaluate(self, record: Mapping[str, Any]) -> bool:
+        if self.field:
+            val = _nested_get(record, self.field)
+            if val is not None:
+                try:
+                    return bool(val)
+                except Exception:
+                    pass
+        if self.metric and self.threshold is not None:
+            val = _nested_get(record, self.metric)
+            if val is not None:
+                try:
+                    fv = float(val)
+                    if self.sense == "gt":
+                        return fv >= float(self.threshold)
+                    return fv <= float(self.threshold)
+                except Exception:
+                    return False
+        raise ValueError(
+            "Unable to extract feasibility label; provide a valid field or metric/threshold"
+        )
+
+
+@dataclass(frozen=True)
+class SeedsPriorConfig:
+    pca_components: int = 8
+    classifier_estimators: int = 200
+    classifier_max_depth: Optional[int] = None
+    generator: str = "gmm"  # 'gmm' or 'flow'
+    gmm_components: int = 6
+    random_state: int = 0
+    quantile_bins: int = 256
+    coeff_abs_max: float = 1.5
+    base_radius_min: float = 0.05
+
+
+class _LatentGenerator:
+    def sample(
+        self, n: int, rng: np.random.Generator
+    ) -> NDArray[np.float64]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def save(self) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class _GmmGenerator(_LatentGenerator):
+    def __init__(self, model: GaussianMixture) -> None:
+        self.model = model
+
+    def sample(self, n: int, rng: np.random.Generator) -> NDArray[np.float64]:
+        # GaussianMixture has its own RNG; clone parameters but sample manually for determinism
+        # We delegate to model.sample but feed deterministic RNG via random_state attribute
+        original_state = self.model.random_state
+        self.model.random_state = int(rng.integers(0, 2**32 - 1))
+        try:
+            xs, _ = self.model.sample(n)
+        finally:
+            self.model.random_state = original_state
+        return xs.astype(np.float64, copy=False)
+
+    def save(self) -> Any:
+        return self.model
+
+
+class _QuantileFlowGenerator(_LatentGenerator):
+    def __init__(self, transformer: QuantileTransformer) -> None:
+        self.transformer = transformer
+
+    def sample(self, n: int, rng: np.random.Generator) -> NDArray[np.float64]:
+        dim = self.transformer.n_features_in_
+        normals = rng.standard_normal((n, dim))
+        uniforms = norm.cdf(normals)
+        uniforms = np.clip(uniforms, 1e-6, 1 - 1e-6)
+        return self.transformer.inverse_transform(uniforms)
+
+    def save(self) -> Any:
+        return self.transformer
+
+
+@dataclass
+class SeedsPriorArtifacts:
+    vectorizer: BoundaryVectorizer
+    scaler: StandardScaler
+    pca: PCA
+    classifier: RandomForestClassifier
+    generator: _LatentGenerator
+    generator_type: str
+
+
+@dataclass
+class PriorSample:
+    boundary: dict[str, Any]
+    feasibility_score: float
+    latent: NDArray[np.float64]
+
+
+class SeedsPriorModel:
+    def __init__(
+        self,
+        artifacts: SeedsPriorArtifacts,
+        config: SeedsPriorConfig,
+        feasibility: FeasibilitySpec,
+    ) -> None:
+        self._artifacts = artifacts
+        self._config = config
+        self._feasibility = feasibility
+
+    @property
+    def config(self) -> SeedsPriorConfig:
+        return self._config
+
+    def save(self, path: Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "config": self._config,
+            "feasibility": self._feasibility,
+            "vectorizer": self._artifacts.vectorizer,
+            "scaler": self._artifacts.scaler,
+            "pca": self._artifacts.pca,
+            "classifier": self._artifacts.classifier,
+            "generator_type": self._artifacts.generator_type,
+            "generator": self._artifacts.generator.save(),
+        }
+        joblib.dump(payload, path)
+        return path
+
+    @classmethod
+    def load(cls, path: Path) -> SeedsPriorModel:
+        payload = joblib.load(Path(path))
+        generator_type = payload["generator_type"]
+        generator: _LatentGenerator
+        if generator_type == "gmm":
+            generator = _GmmGenerator(payload["generator"])
+        elif generator_type == "flow":
+            generator = _QuantileFlowGenerator(payload["generator"])
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown generator type: {generator_type}")
+        artifacts = SeedsPriorArtifacts(
+            vectorizer=payload["vectorizer"],
+            scaler=payload["scaler"],
+            pca=payload["pca"],
+            classifier=payload["classifier"],
+            generator=generator,
+            generator_type=generator_type,
+        )
+        return cls(artifacts, payload["config"], payload["feasibility"])
+
+    def predict_feasibility(self, boundary: Mapping[str, Any]) -> float:
+        vec = self._artifacts.vectorizer.transform(boundary)
+        scaled = self._artifacts.scaler.transform(vec.reshape(1, -1))
+        latent = self._artifacts.pca.transform(scaled)
+        prob = self._artifacts.classifier.predict_proba(latent)[0][1]
+        return float(prob)
+
+    def sample(
+        self,
+        count: int,
+        *,
+        nfp: Optional[int] = None,
+        min_feasibility: float = 0.5,
+        max_draw_batches: int = 50,
+        batch_size: Optional[int] = None,
+        seed: Optional[int] = None,
+    ) -> List[PriorSample]:
+        rng = np.random.default_rng(seed)
+        accepted: List[PriorSample] = []
+        draws_per_batch = batch_size or max(count * 2, 8)
+        tries = 0
+        classifier = self._artifacts.classifier
+        pca = self._artifacts.pca
+        scaler = self._artifacts.scaler
+        vectorizer = self._artifacts.vectorizer
+        coeff_abs_max = self._config.coeff_abs_max
+        base_radius_min = self._config.base_radius_min
+        while len(accepted) < count and tries < max_draw_batches:
+            latent = self._artifacts.generator.sample(draws_per_batch, rng)
+            probs = classifier.predict_proba(latent)[:, 1]
+            for z, prob in zip(latent, probs):
+                if prob < min_feasibility:
+                    continue
+                scaled_vec = pca.inverse_transform(z.reshape(1, -1))
+                raw_vec = scaler.inverse_transform(scaled_vec)[0]
+                if nfp is not None:
+                    raw_vec[vectorizer.nfp_index] = float(nfp)
+                boundary = vectorizer.inverse_transform(
+                    raw_vec,
+                    override_nfp=nfp,
+                    coeff_abs_max=coeff_abs_max,
+                    base_radius_min=base_radius_min,
+                )
+                try:
+                    validate_boundary(boundary)
+                except Exception:
+                    continue
+                accepted.append(
+                    PriorSample(boundary=boundary, feasibility_score=float(prob), latent=z)
+                )
+                if len(accepted) >= count:
+                    break
+            tries += 1
+        return accepted
+
+
+def _extract_boundary(record: Mapping[str, Any]) -> dict[str, Any]:
+    boundary = record.get("boundary")
+    if isinstance(boundary, Mapping):
+        out: dict[str, Any] = {
+            "r_cos": _ensure_nested_list(boundary.get("r_cos")),
+            "r_sin": _ensure_nested_list(boundary.get("r_sin")),
+            "z_cos": _ensure_nested_list(boundary.get("z_cos")),
+            "z_sin": _ensure_nested_list(boundary.get("z_sin")),
+            "n_field_periods": _round_int(boundary.get("n_field_periods", 3)),
+            "is_stellarator_symmetric": bool(boundary.get("is_stellarator_symmetric", True)),
+        }
+        if out["r_cos"] is None:
+            raise ValueError("Boundary missing r_cos coefficients")
+        if out["z_sin"] is None:
+            raise ValueError("Boundary missing z_sin coefficients")
+        return out
+
+    # Reconstruct from flattened keys boundary.<field>.<m>.<n>
+    r_fields: dict[str, MutableMapping[tuple[int, int], float]] = {
+        "r_cos": {},
+        "z_sin": {},
+        "r_sin": {},
+        "z_cos": {},
+    }
+    nfp_val = _round_int(record.get("boundary.n_field_periods", 3))
+    for key, val in record.items():
+        if not isinstance(key, str) or not key.startswith("boundary."):
+            continue
+        parts = key.split(".")
+        if len(parts) == 2 and parts[1] == "n_field_periods":
+            nfp_val = _round_int(val)
+            continue
+        if len(parts) != 4:
+            continue
+        field = parts[1]
+        if field not in r_fields:
+            continue
+        try:
+            m = int(parts[2])
+            n = int(parts[3])
+            r_fields[field][(m, n)] = float(val)
+        except Exception:
+            continue
+
+    def _assemble(field: str) -> Optional[CoeffArray]:
+        entries = r_fields[field]
+        if not entries:
+            return None if field in {"r_sin", "z_cos"} else _make_grid((1, 1))
+        max_m = max(m for m, _ in entries.keys())
+        max_n = max(n for _, n in entries.keys())
+        grid = _make_grid((max_m + 1, max_n + 1))
+        for (m, n), v in entries.items():
+            if m < len(grid) and n < len(grid[0]):
+                grid[m][n] = v
+        return grid
+
+    r_cos = _assemble("r_cos")
+    z_sin = _assemble("z_sin")
+    if r_cos is None or z_sin is None:
+        raise ValueError("Unable to reconstruct boundary coefficients")
+    return {
+        "r_cos": r_cos,
+        "r_sin": _assemble("r_sin"),
+        "z_cos": _assemble("z_cos"),
+        "z_sin": z_sin,
+        "n_field_periods": nfp_val,
+        "is_stellarator_symmetric": True,
+    }
+
+
+def train_prior(
+    records: Sequence[Mapping[str, Any]],
+    config: SeedsPriorConfig,
+    feasibility: FeasibilitySpec,
+    *,
+    nfp: Optional[int] = None,
+    min_feasible: int = 8,
+) -> SeedsPriorModel:
+    if not records:
+        raise ValueError("No records provided to train prior")
+    boundaries: List[dict[str, Any]] = []
+    labels: List[bool] = []
+    for rec in records:
+        b = _extract_boundary(rec)
+        if nfp is not None and b.get("n_field_periods") != nfp:
+            continue
+        try:
+            label = feasibility.evaluate(rec)
+        except ValueError:
+            continue
+        boundaries.append(b)
+        labels.append(bool(label))
+    if not boundaries:
+        raise ValueError("No boundaries remaining after filtering for NFP/labels")
+    positives = sum(1 for x in labels if x)
+    if positives < min_feasible:
+        raise ValueError(f"Not enough feasible examples ({positives}) to fit generative model")
+    vectorizer = BoundaryVectorizer().fit(boundaries)
+    X = np.stack([vectorizer.transform(b) for b in boundaries])
+    scaler = StandardScaler()
+    X_scaled = scaler.fit_transform(X)
+    latent_dim = min(config.pca_components, X_scaled.shape[1], len(boundaries))
+    latent_dim = max(1, latent_dim)
+    pca = PCA(n_components=latent_dim, random_state=config.random_state)
+    Z = pca.fit_transform(X_scaled)
+    clf = RandomForestClassifier(
+        n_estimators=config.classifier_estimators,
+        max_depth=config.classifier_max_depth,
+        random_state=config.random_state,
+        class_weight="balanced",
+    )
+    clf.fit(Z, labels)
+    feasible_idx = np.array(labels, dtype=bool)
+    Z_feasible = Z[feasible_idx]
+    generator: _LatentGenerator
+    generator_type: str
+    if config.generator == "flow":
+        qt = QuantileTransformer(
+            n_quantiles=min(config.quantile_bins, len(Z_feasible)),
+            output_distribution="uniform",
+            random_state=config.random_state,
+        )
+        qt.fit(Z_feasible)
+        generator = _QuantileFlowGenerator(qt)
+        generator_type = "flow"
+    else:
+        n_components = min(config.gmm_components, len(Z_feasible))
+        n_components = max(1, n_components)
+        gmm = GaussianMixture(
+            n_components=n_components,
+            covariance_type="full",
+            reg_covar=1e-6,
+            random_state=config.random_state,
+        )
+        gmm.fit(Z_feasible)
+        generator = _GmmGenerator(gmm)
+        generator_type = "gmm"
+    artifacts = SeedsPriorArtifacts(
+        vectorizer=vectorizer,
+        scaler=scaler,
+        pca=pca,
+        classifier=clf,
+        generator=generator,
+        generator_type=generator_type,
+    )
+    return SeedsPriorModel(artifacts, config, feasibility)
+
+
+def load_jsonl(path: Path) -> List[Mapping[str, Any]]:
+    records: List[Mapping[str, Any]] = []
+    with Path(path).open("r") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+__all__ = [
+    "BoundaryVectorizer",
+    "FeasibilitySpec",
+    "SeedsPriorConfig",
+    "SeedsPriorModel",
+    "PriorSample",
+    "train_prior",
+    "load_jsonl",
+]

--- a/src/constelx/data/seeds_prior.py
+++ b/src/constelx/data/seeds_prior.py
@@ -174,7 +174,7 @@ class BoundaryVectorizer:
         for fname in self.fields:
             sl = self._offsets[fname]
             arr = vec[sl].reshape((self.m_dim, self.n_dim))
-            arr = np.clip(arr, -coeff_abs_max, coeff_abs_max)
+            np.clip(arr, -coeff_abs_max, coeff_abs_max, out=arr)
             if fname == "r_cos":
                 arr[0, base_idx] = float(max(base_radius_min, arr[0, base_idx]))
             result[fname] = arr.tolist()

--- a/src/constelx/eval/boozer.py
+++ b/src/constelx/eval/boozer.py
@@ -1,0 +1,201 @@
+"""Boozer-space quasi-symmetry and quasi-isodynamic proxy metrics.
+
+This module offers a lightweight, dependency-free (besides NumPy) implementation of
+proxy observables that correlate with quasi-symmetry (QS) and quasi-isodynamic (QI)
+quality. The proxies intentionally avoid heavy Boozer transforms by operating on the
+existing truncated Fourier representation of stellarator-symmetric boundaries.
+
+The design goals are:
+- Deterministic, cheap to evaluate (O(m n n_theta n_phi))
+- Bounded residuals in [0, 1] so that downstream constraint handlers can rely on
+  consistent scales
+- Simple to integrate into guardrails or proxy-evaluation paths before the real
+  evaluator is available
+
+Example
+-------
+>>> from constelx.physics.constel_api import example_boundary
+>>> proxies = compute_boozer_proxies(example_boundary())
+>>> proxies.qs_residual <= 1.0
+True
+>>> proxies.to_dict(prefix="proxy_")  # doctest: +ELLIPSIS
+{'proxy_b_mean': ..., 'proxy_b_std_fraction': ..., ...}
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+from .boundary_fourier import BoundaryFourier
+
+__all__ = ["BoozerProxies", "compute_boozer_proxies"]
+
+_EPS = 1e-12
+
+
+def _bounded_ratio(value: float) -> float:
+    """Map a non-negative value to [0, 1) using ``x -> x / (1 + x)``."""
+    v = max(0.0, float(value))
+    return v / (1.0 + v)
+
+
+@dataclass(frozen=True)
+class BoozerProxies:
+    """Container for Boozer-derived proxy metrics."""
+
+    b_mean: float
+    b_std_fraction: float
+    mirror_ratio: float
+    qs_residual: float
+    qs_quality: float
+    qi_residual: float
+    qi_quality: float
+
+    @staticmethod
+    def zeros() -> "BoozerProxies":
+        """Return a zero-initialized proxy payload."""
+        return BoozerProxies(
+            b_mean=0.0,
+            b_std_fraction=0.0,
+            mirror_ratio=0.0,
+            qs_residual=0.0,
+            qs_quality=1.0,
+            qi_residual=0.0,
+            qi_quality=1.0,
+        )
+
+    def to_dict(self, *, prefix: str | None = None) -> dict[str, float]:
+        """Convert proxies to a dict with optional key prefixing."""
+        data = {
+            "b_mean": float(self.b_mean),
+            "b_std_fraction": float(self.b_std_fraction),
+            "mirror_ratio": float(self.mirror_ratio),
+            "qs_residual": float(self.qs_residual),
+            "qs_quality": float(self.qs_quality),
+            "qi_residual": float(self.qi_residual),
+            "qi_quality": float(self.qi_quality),
+        }
+        if prefix:
+            return {f"{prefix}{k}": v for k, v in data.items()}
+        return data
+
+
+def _angles_for_sampling(n_theta: int, n_phi: int, nfp: int) -> tuple[np.ndarray, np.ndarray]:
+    thetas = np.linspace(0.0, 2.0 * math.pi, num=n_theta, endpoint=False, dtype=float)
+    # Toroidal angle spans one field period (2π / nfp)
+    phis = np.linspace(0.0, 2.0 * math.pi / max(1, nfp), num=n_phi, endpoint=False, dtype=float)
+    return thetas, phis
+
+
+def _sample_surface_arrays(
+    bf: BoundaryFourier, thetas: np.ndarray, phis: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return (R, Z) arrays sampled on the theta/phi grid."""
+    theta_grid, phi_grid = np.meshgrid(thetas, phis, indexing="ij")
+    R = np.zeros_like(theta_grid, dtype=float)
+    Z = np.zeros_like(theta_grid, dtype=float)
+
+    for m in range(bf.m_dim):
+        m_theta = m * theta_grid
+        for j in range(bf.n_dim):
+            n = j - bf.n_offset
+            phase = m_theta - n * phi_grid
+            a = float(bf.r_cos[m][j])
+            b = float(bf.z_sin[m][j])
+            if a != 0.0:
+                R += a * np.cos(phase)
+            if b != 0.0:
+                Z += b * np.sin(phase)
+    return R, Z
+
+
+def compute_boozer_proxies(
+    boundary: Mapping[str, Any],
+    *,
+    helicity: int | None = None,
+    n_theta: int = 24,
+    n_phi: int = 24,
+) -> BoozerProxies:
+    """Compute Boozer-space proxy metrics from a boundary description.
+
+    Parameters
+    ----------
+    boundary:
+        Mapping compatible with ``SurfaceRZFourier`` (requires ``r_cos`` and ``z_sin`` fields).
+    helicity:
+        Integer Boozer helicity ``N`` for the quasi-symmetry residual. Defaults to
+        ``boundary['n_field_periods']``.
+    n_theta, n_phi:
+        Sampling resolution for the coarse grid used to evaluate the proxies.
+
+    Returns
+    -------
+    BoozerProxies
+        Container with bounded residuals and quality scores.
+    """
+
+    try:
+        bf = BoundaryFourier.from_surface_dict(dict(boundary))
+    except Exception:
+        return BoozerProxies.zeros()
+
+    if n_theta <= 4 or n_phi <= 4:
+        raise ValueError("n_theta and n_phi must be >= 5 for meaningful sampling")
+
+    thetas, phis = _angles_for_sampling(int(n_theta), int(n_phi), bf.nfp)
+    R, _ = _sample_surface_arrays(bf, thetas, phis)
+
+    r_mean = float(np.mean(R))
+    if not math.isfinite(r_mean) or abs(r_mean) <= _EPS:
+        return BoozerProxies.zeros()
+
+    B = r_mean / np.clip(np.abs(R), _EPS, None)
+    B_mean = float(np.mean(B))
+    B_std_fraction = _bounded_ratio(float(np.std(B) / (B_mean + _EPS)))
+    B_max = float(np.max(B))
+    B_min = float(np.min(B))
+    mirror_ratio = _bounded_ratio((B_max - B_min) / (B_min + _EPS))
+
+    if helicity is None:
+        helicity = int(boundary.get("n_field_periods", bf.nfp))
+    helicity = int(helicity)
+    theta_grid, phi_grid = np.meshgrid(thetas, phis, indexing="ij")
+    alpha = (theta_grid - helicity * phi_grid) % (2.0 * math.pi)
+    n_bins = max(8, int(n_phi))
+    bin_idx = np.floor(alpha / (2.0 * math.pi) * n_bins).astype(int)
+    bin_idx = np.mod(bin_idx, n_bins)
+
+    flat_bins = bin_idx.ravel()
+    flat_B = B.ravel()
+
+    sums = np.zeros(n_bins, dtype=float)
+    counts = np.zeros(n_bins, dtype=int)
+    np.add.at(sums, flat_bins, flat_B)
+    np.add.at(counts, flat_bins, 1)
+
+    means = np.divide(sums, counts, out=np.zeros_like(sums), where=counts > 0)
+    centered = flat_B - means[flat_bins]
+    qs_rms = math.sqrt(float(np.mean(centered * centered)))
+    qs_res_norm = qs_rms / (B_mean + _EPS)
+    qs_residual = _bounded_ratio(qs_res_norm)
+    qs_quality = 1.0 - qs_residual
+
+    B_min_phi = np.min(B, axis=0)
+    mean_min = float(np.mean(B_min_phi))
+    min_spread = float(np.std(B_min_phi) / (mean_min + _EPS))
+    qi_residual = _bounded_ratio(min_spread)
+    qi_quality = 1.0 - qi_residual
+
+    return BoozerProxies(
+        b_mean=B_mean,
+        b_std_fraction=B_std_fraction,
+        mirror_ratio=mirror_ratio,
+        qs_residual=qs_residual,
+        qs_quality=qs_quality,
+        qi_residual=qi_residual,
+        qi_quality=qi_quality,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,13 @@ from typing import Any, Dict, List
 
 import pytest
 
-from constelx.eval.boundary_param import sample_random
-
 # Ensure src/ is on sys.path when running tests without installation.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 if SRC_PATH.is_dir() and str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
+
+from constelx.eval.boundary_param import sample_random
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ SRC_PATH = PROJECT_ROOT / "src"
 if SRC_PATH.is_dir() and str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
-from constelx.eval.boundary_param import sample_random
-
 
 @pytest.fixture
 def torch_module() -> object:
@@ -30,6 +28,8 @@ def surrogate_modules(torch_module: object) -> tuple[object, type, object, type]
 
 
 def _build_seeds_prior_records(count: int = 96) -> List[Dict[str, Any]]:
+    from constelx.eval.boundary_param import sample_random
+
     records: List[Dict[str, Any]] = []
     for idx in range(count):
         b = sample_random(nfp=3, seed=idx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+from typing import Any, Dict, List
 
 import pytest
+
+from constelx.eval.boundary_param import sample_random
 
 # Ensure src/ is on sys.path when running tests without installation.
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -23,3 +27,33 @@ def surrogate_modules(torch_module: object) -> tuple[object, type, object, type]
     from constelx.surrogate.train import MLP
 
     return torch_module, MLP, load_scorer, SurrogateScreenError
+
+
+def _build_seeds_prior_records(count: int = 96) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    for idx in range(count):
+        b = sample_random(nfp=3, seed=idx)
+        # Introduce deterministic diversity across higher modes to give PCA signal
+        scale = 0.01 * ((idx % 5) - 2)
+        if len(b["r_cos"]) > 2 and len(b["r_cos"][2]) > 4:
+            b["r_cos"][2][4] = float(scale)
+            b["z_sin"][2][4] = float(-scale)
+        amp = abs(b["r_cos"][1][5]) + abs(b["z_sin"][1][5])
+        metric = float(amp + 0.5 * abs(scale))
+        feasible = metric < 0.09
+        records.append({"boundary": b, "metrics": {"feasible": feasible, "metric": metric}})
+    return records
+
+
+@pytest.fixture()
+def seeds_prior_records() -> List[Dict[str, Any]]:
+    return _build_seeds_prior_records()
+
+
+@pytest.fixture()
+def seeds_prior_dataset_jsonl(tmp_path: Path, seeds_prior_records: List[Dict[str, Any]]) -> Path:
+    path = tmp_path / "dataset.jsonl"
+    with path.open("w") as f:
+        for rec in seeds_prior_records:
+            f.write(json.dumps(rec) + "\n")
+    return path

--- a/tests/test_agent_seed_prior.py
+++ b/tests/test_agent_seed_prior.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pandas as pd
+from typer.testing import CliRunner
+
+from constelx.cli import app
+from constelx.data.seeds_prior import FeasibilitySpec, SeedsPriorConfig, train_prior
+
+
+def test_agent_seed_mode_prior(tmp_path, seeds_prior_records) -> None:
+    config = SeedsPriorConfig(
+        pca_components=5,
+        generator="gmm",
+        gmm_components=5,
+        random_state=2,
+    )
+    model = train_prior(
+        seeds_prior_records,
+        config,
+        FeasibilitySpec(field="metrics.feasible"),
+        nfp=3,
+    )
+    model_path = tmp_path / "prior.joblib"
+    model.save(model_path)
+
+    runs_dir = tmp_path / "runs"
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "agent",
+            "run",
+            "--nfp",
+            "3",
+            "--budget",
+            "3",
+            "--seed",
+            "4",
+            "--runs-dir",
+            str(runs_dir),
+            "--seed-mode",
+            "prior",
+            "--seed-prior",
+            str(model_path),
+            "--seed-prior-min-prob",
+            "0.0",
+            "--seed-prior-batch",
+            "12",
+            "--seed-prior-draw-batches",
+            "6",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    run_dirs = [p for p in runs_dir.iterdir() if p.is_dir()]
+    assert run_dirs, "agent run directory not created"
+    metrics_csv = run_dirs[0] / "metrics.csv"
+    df = pd.read_csv(metrics_csv)
+    assert "seed_source" in df.columns
+    assert (df["seed_source"] == "prior").any()

--- a/tests/test_cli_prior.py
+++ b/tests/test_cli_prior.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from constelx.cli import app
+
+
+def test_cli_prior_train_and_sample(tmp_path: Path, seeds_prior_dataset_jsonl: Path) -> None:
+    runner = CliRunner()
+    model_path = tmp_path / "prior.joblib"
+    result = runner.invoke(
+        app,
+        [
+            "data",
+            "prior-train",
+            str(seeds_prior_dataset_jsonl),
+            "--out",
+            str(model_path),
+            "--limit",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert model_path.exists()
+
+    seeds_path = tmp_path / "seeds.jsonl"
+    result = runner.invoke(
+        app,
+        [
+            "data",
+            "prior-sample",
+            str(model_path),
+            "--out",
+            str(seeds_path),
+            "--count",
+            "5",
+            "--nfp",
+            "3",
+            "--min-feasibility",
+            "0.0",
+            "--batch-size",
+            "16",
+            "--max-draw-batches",
+            "8",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    lines = seeds_path.read_text().strip().splitlines()
+    assert len(lines) == 5
+    record = json.loads(lines[0])
+    assert "boundary" in record and "feasibility_score" in record

--- a/tests/test_data_seeds_prior.py
+++ b/tests/test_data_seeds_prior.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from constelx.data.seeds_prior import (
+    FeasibilitySpec,
+    SeedsPriorConfig,
+    SeedsPriorModel,
+    train_prior,
+)
+from constelx.eval.boundary_param import validate
+
+
+def test_train_prior_gmm_and_sample(seeds_prior_records, tmp_path):
+    config = SeedsPriorConfig(
+        pca_components=5,
+        generator="gmm",
+        gmm_components=4,
+        random_state=0,
+    )
+    model = train_prior(
+        seeds_prior_records,
+        config,
+        FeasibilitySpec(field="metrics.feasible"),
+        nfp=3,
+    )
+    samples = model.sample(count=6, nfp=3, min_feasibility=0.05, seed=1)
+    assert len(samples) == 6
+    for sample in samples:
+        validate(sample.boundary)
+        assert sample.boundary["n_field_periods"] == 3
+        assert sample.feasibility_score >= 0.05
+    model_path = tmp_path / "prior.joblib"
+    model.save(model_path)
+    loaded = SeedsPriorModel.load(model_path)
+    score = loaded.predict_feasibility(samples[0].boundary)
+    assert 0.0 <= score <= 1.0
+
+
+def test_train_prior_flow_metric_threshold(seeds_prior_records):
+    spec = FeasibilitySpec(
+        field=None,
+        metric="metrics.metric",
+        threshold=0.09,
+        sense="lt",
+    )
+    config = SeedsPriorConfig(
+        pca_components=4,
+        generator="flow",
+        quantile_bins=48,
+        random_state=3,
+    )
+    model = train_prior(seeds_prior_records, config, spec, nfp=3)
+    samples = model.sample(count=4, nfp=3, min_feasibility=0.2, seed=3)
+    # Flow sampler may reject a few draws; ensure we still get at least two
+    assert len(samples) >= 2
+    for sample in samples:
+        validate(sample.boundary)

--- a/tests/test_eval_boozer.py
+++ b/tests/test_eval_boozer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from constelx.eval.boozer import compute_boozer_proxies
+from constelx.eval.boundary_fourier import BoundaryFourier
+from constelx.physics.constel_api import evaluate_boundary, example_boundary
+
+
+def test_boozer_proxies_bounded() -> None:
+    proxies = compute_boozer_proxies(example_boundary())
+    assert math.isfinite(proxies.b_mean)
+    assert 0.0 <= proxies.b_std_fraction <= 1.0
+    assert 0.0 <= proxies.mirror_ratio <= 1.0
+    assert 0.0 <= proxies.qs_residual <= 1.0
+    assert 0.0 <= proxies.qi_residual <= 1.0
+    assert proxies.qs_quality == pytest.approx(1.0 - proxies.qs_residual)
+    assert proxies.qi_quality == pytest.approx(1.0 - proxies.qi_residual)
+
+
+def test_boozer_proxies_prefix_dict() -> None:
+    proxies = compute_boozer_proxies(example_boundary())
+    prefixed = proxies.to_dict(prefix="proxy_")
+    assert all(key.startswith("proxy_") for key in prefixed)
+    assert prefixed["proxy_qs_quality"] == proxies.qs_quality
+
+
+def test_boozer_residuals_respond_to_deformation() -> None:
+    base = example_boundary()
+    base_proxies = compute_boozer_proxies(base)
+
+    bf = BoundaryFourier.from_surface_dict(base)
+    i, j = bf.idx(1, 2)
+    bf.r_cos[i][j] = 0.4  # introduce additional helical content
+    bf.z_sin[i][j] = 0.4
+    distorted = bf.to_surface_rz_fourier_dict()
+    distorted_proxies = compute_boozer_proxies(distorted)
+
+    assert distorted_proxies.qs_residual > base_proxies.qs_residual
+    assert distorted_proxies.qi_residual >= base_proxies.qi_residual
+
+
+def test_evaluate_boundary_adds_proxy_metrics() -> None:
+    metrics = evaluate_boundary(example_boundary(), use_real=False)
+    assert "proxy_qs_residual" in metrics
+    assert "proxy_qi_quality" in metrics


### PR DESCRIPTION
## Summary
- introduce seeds_prior module with PCA->model training and sampling helpers
- wire agent CLI switches for prior-based seeding and surface provenance logging
- document new data commands and export the API for downstream reuse

## Testing
- pytest tests/test_cli_prior.py tests/test_data_seeds_prior.py tests/test_agent_seed_prior.py
