### PR TITLE
docs: add PCFM usage snippets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,12 @@ These guidelines help contributors build, test, and extend the ConStelX starter 
     - Ready-to-use specs live in `examples/pcfm_*.json` (norm, ratio, product, aspect-ratio band, edge iota ratio, QS residual band, clearance floor).
     - Tuning: CLI flags `--pcfm-gn-iters/--pcfm-damping/--pcfm-tol` or JSON top-level `{gn_iters,damping,tol}`.
     - See [README.md#pcfm-correction-gaussnewton-projection](README.md#pcfm-correction-gaussnewton-projection) for additional context and safety guidance.
+- ConStellaration parity:
+  - Forward metrics via official evaluator: `constelx eval forward --boundary-json examples/boundary.json --use-real --use-physics --problem p1` (set `CONSTELX_USE_REAL_EVAL=1` to make this the default).
+  - Score aggregation check: `constelx eval score --metrics-json examples/metrics_small.json --problem p1` (or
+    `--metrics-file runs/<ts>/metrics.csv --problem p1`).
+  - Run gated parity tests (requires `pip install -e ".[physics]"` and the evaluator deps):
+    `CONSTELX_RUN_PHYSICS_TESTS=1 pytest -q -k scoring_parity`.
 
 ## Pre-commit Hooks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,16 +21,23 @@ These guidelines help contributors build, test, and extend the ConStelX starter 
 - CLI help: `constelx --help`
   - Quick smoke: `constelx data fetch --nfp 3 --limit 8`
 - E2E (small): `constelx agent run --nfp 3 --budget 5 --seed 0`
-  - With PCFM correction:
-  - Norm eq: `examples/pcfm_norm.json`
-  - Ratio eq: `examples/pcfm_ratio.json`
-  - Product eq: `examples/pcfm_product.json`
-  - Aspect-ratio band: `examples/pcfm_ar_band.json`
-  - Edge iota ratio: `examples/pcfm_edge_iota.json`
-  - QS residual band (Boozer proxy): `examples/pcfm_qs_band.json`
-  - Clearance floor: `examples/pcfm_clearance.json`
-  - Command: `constelx agent run --nfp 3 --budget 4 --correction pcfm --constraints-file <json>`
-    - Tuning: CLI flags or JSON top-level `{gn_iters,damping,tol}`
+  - With PCFM correction (Gauss–Newton projection with clamped steps + geometry revalidation):
+    ```json
+    [
+      {
+        "type": "norm_eq",
+        "radius": 0.06,
+        "terms": [
+          {"field": "r_cos", "i": 1, "j": 5, "w": 1.0},
+          {"field": "z_sin", "i": 1, "j": 5, "w": 1.0}
+        ]
+      }
+    ]
+    ```
+    - Launch: `constelx agent run --nfp 3 --budget 4 --correction pcfm --constraints-file examples/pcfm_norm.json`
+    - Ready-to-use specs live in `examples/pcfm_*.json` (norm, ratio, product, aspect-ratio band, edge iota ratio, QS residual band, clearance floor).
+    - Tuning: CLI flags `--pcfm-gn-iters/--pcfm-damping/--pcfm-tol` or JSON top-level `{gn_iters,damping,tol}`.
+    - See [README.md#pcfm-correction-gaussnewton-projection](README.md#pcfm-correction-gaussnewton-projection) for additional context and safety guidance.
 
 ## Pre-commit Hooks
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Evaluation
 Evaluator knobs & parity
 - `constelx eval problems` lists each challenge problem together with the metrics the
   evaluator expects so you can sanity-check parity before long runs.
+- Real evaluator path: append `--use-physics --use-real --problem p1` (or export
+  `CONSTELX_USE_REAL_EVAL=1`) on `constelx eval forward`, `opt run`, or `agent run` to
+  route calls through the official ConStellaration evaluator. Example:
+  `constelx eval forward --boundary-json examples/boundary.json --use-real --use-physics --problem p1`.
 - Timeout/backoff knobs: `CONSTELX_REAL_TIMEOUT_MS`, `CONSTELX_REAL_RETRIES`, and
   `CONSTELX_REAL_BACKOFF` tune the real evaluator timeout loop.
 - Logging: set `CONSTELX_EVAL_LOG_DIR=/path/to/logs` to capture one JSON file per

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,10 @@
 # TODOs
 
 ## Sequential Tasks (next up)
-1. [#28] ConStellaration evaluator wiring follow-ups
-   - Core landed via PR #36; finish robustness/docs cleanup from #34 and reflect parity guidance before closing.
-2. [#40] BoTorch qNEI baseline (optional extra)
+1. [#40] BoTorch qNEI baseline (optional extra)
    - Import-guarded baseline with feasibility-aware acquisition and CLI/tests/docs.
 
-Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pending #28/#30 and the qNEI baseline in #40).
+Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pending #30 and the qNEI baseline in #40).
 
 ## Parallelizable Tasks
 - [#45] Data-driven seeds prior polish — rerun against HF ingestion once #30 lands, evaluate the flow-based variant, and fold the findings into docs before closing the issue.
@@ -15,6 +13,8 @@ Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pe
   (De-dup with Sequential list as work starts.)
 
 ## Completed Recently
+- [#28] ConStellaration evaluator wiring follow-ups — README/AGENTS now document `--use-real`
+  usage, parity workflow, and environment knobs (PR #98 follow-up).
 - [#20] PCFM correction docs — README/AGENTS now ship norm JSON snippet, command example, and Gauss–Newton safety notes (PR #98).
 - [#30] Real dataset ingestion (HF dataset) + Parquet cache — added `--source hf`, robust Parquet export with nested→flat conversion, examples, README/docs, and tests (PR #96).
 - [#46] Boozer/QS–QI evaluator bridge — dedicated evaluator wiring now threads proxy metrics through CLI physics toggles and documentation (PR #89).

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@ Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pe
   (De-dup with Sequential list as work starts.)
 
 ## Completed Recently
+- [#20] PCFM correction docs — README/AGENTS now ship norm JSON snippet, command example, and Gauss–Newton safety notes (PR #98).
 - [#30] Real dataset ingestion (HF dataset) + Parquet cache — added `--source hf`, robust Parquet export with nested→flat conversion, examples, README/docs, and tests (PR #96).
 - [#46] Boozer/QS–QI evaluator bridge — dedicated evaluator wiring now threads proxy metrics through CLI physics toggles and documentation (PR #89).
 - [#45] Data-driven seeds prior pipeline — training/sampling CLI added, agent seeding wired, and regression tests shipped (PR #90); polish tracked above before closing.


### PR DESCRIPTION
## Summary
- document the PCFM norm constraint snippet inline in README and AGENTS
- explain the Gauss–Newton projection safety guardrails and launch command
- link AGENTS guidance back to the README anchor for additional context

## Testing
- pre-commit run -a