### PR TITLE
feat: add botorch qnei baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Optimization
 - Toy sphere: `constelx opt cmaes --toy --budget 20 --seed 0`
 - Boundary mode: `constelx opt cmaes --nfp 3 --budget 50 --seed 0`
 
-Optimization baselines (trust‑constr / ALM / NGOpt)
+Optimization baselines (trust‑constr / ALM / qNEI / NGOpt)
 - Trust‑constr (2D helical coefficients):
   `constelx opt run --baseline trust-constr --nfp 3 --budget 10`
 - Augmented‑Lagrangian (simple penalty outer loop):
@@ -91,13 +91,18 @@ Optimization baselines (trust‑constr / ALM / NGOpt)
   scoring via the shared evaluator.
 - Nevergrad NGOpt (augmented-Lagrangian polisher):
   `constelx opt run --baseline ngopt --nfp 3 --budget 10`
+- BoTorch qNEI (feasibility-aware acquisition):
+  `constelx opt run --baseline qnei --nfp 3 --budget 10`
+  Requires `pip install -e ".[bo]"` (or `constelx[bo]`) and optimizes the same
+  two-dimensional helical parameterization using a constraint-aware qNEI loop.
 - With physics path (requires problem id):
   `constelx opt run --baseline trust-constr --nfp 3 --budget 10 --use-physics --problem p1`
 - Pareto sweep (Problem 3 placeholder):
   `constelx opt pareto --budget 16 --sweeps 5 --seed 0 --json-out pareto.json`
   When `--use-physics` is set, metrics and scoring route through the official evaluator
   if available; otherwise the command falls back to the placeholder path.
-  (Install the `evolution` extra to enable CMA-ES and NGOpt: `pip install -e ".[evolution]"`.)
+  (Install the `evolution` extra to enable CMA-ES and NGOpt: `pip install -e ".[evolution]"`.
+  Install the `bo` extra to enable the BoTorch qNEI baseline: `pip install -e ".[bo]"`.)
 
 Agent
 - Random search: `constelx agent run --nfp 3 --budget 6 --seed 0 --runs-dir runs`

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,8 @@
 # TODOs
 
 ## Sequential Tasks (next up)
-1. [#40] BoTorch qNEI baseline (optional extra)
-   - Import-guarded baseline with feasibility-aware acquisition and CLI/tests/docs.
 
-Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pending #30 and the qNEI baseline in #40).
+Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pending #30).
 
 ## Parallelizable Tasks
 - [#45] Data-driven seeds prior polish — rerun against HF ingestion once #30 lands, evaluate the flow-based variant, and fold the findings into docs before closing the issue.
@@ -13,6 +11,7 @@ Tracking: [#27] remains open until the PR-01…06 checklist is fully cleared (pe
   (De-dup with Sequential list as work starts.)
 
 ## Completed Recently
+- [#40] BoTorch qNEI baseline — import-guarded feasibility-aware qNEI baseline with CLI/tests/docs.
 - [#28] ConStellaration evaluator wiring follow-ups — README/AGENTS now document `--use-real`
   usage, parity workflow, and environment knobs (PR #98 follow-up).
 - [#20] PCFM correction docs — README/AGENTS now ship norm JSON snippet, command example, and Gauss–Newton safety notes (PR #98).

--- a/src/constelx/cli.py
+++ b/src/constelx/cli.py
@@ -558,7 +558,7 @@ def opt_cmaes(
 @opt_app.command("run")
 def opt_run(
     baseline: str = typer.Option(
-        "trust-constr", help="Baseline: trust-constr|alm|desc-trust|ngopt|cmaes"
+        "trust-constr", help="Baseline: trust-constr|alm|desc-trust|ngopt|qnei|cmaes"
     ),
     nfp: int = typer.Option(3, help="Boundary NFP for boundary-mode optimization."),
     budget: int = typer.Option(50, help="Iteration budget (outer*inner for ALM)."),
@@ -594,7 +594,13 @@ def opt_run(
         opt_cmaes(nfp=nfp, budget=budget, seed=seed, toy=False)
         return None
 
-    from .optim.baselines import BaselineConfig, run_alm, run_ngopt, run_trust_constr
+    from .optim.baselines import (
+        BaselineConfig,
+        run_alm,
+        run_botorch_qnei,
+        run_ngopt,
+        run_trust_constr,
+    )
 
     cfg = BaselineConfig(
         nfp=nfp,
@@ -615,6 +621,8 @@ def opt_run(
             x, val = run_alm(cfg)
         elif baseline_key in {"ngopt", "nevergrad"}:
             x, val = run_ngopt(cfg)
+        elif baseline_key in {"qnei", "botorch", "bo", "botorch-qnei"}:
+            x, val = run_botorch_qnei(cfg)
         elif baseline_key in {"desc", "desc-tr", "desc-trust", "desc_trust"}:
             from .optim.desc_trust_region import (
                 DescTrustRegionConfig,

--- a/tests/test_cli_opt_run.py
+++ b/tests/test_cli_opt_run.py
@@ -64,6 +64,26 @@ def test_opt_run_ngopt_smoke() -> None:
     assert "Best x:" in result.stdout
 
 
+def test_opt_run_qnei_smoke() -> None:
+    pytest.importorskip("botorch")
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "opt",
+            "run",
+            "--baseline",
+            "qnei",
+            "--nfp",
+            "3",
+            "--budget",
+            "5",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Best x:" in result.stdout
+
+
 def test_opt_run_unknown_baseline_errors() -> None:
     runner = CliRunner()
     result = runner.invoke(
@@ -121,3 +141,23 @@ def test_opt_run_ngopt_missing_dependency(monkeypatch: pytest.MonkeyPatch) -> No
     )
     assert result.exit_code != 0
     assert "Nevergrad is required" in result.stdout or "Nevergrad is required" in result.stderr
+
+
+def test_opt_run_qnei_missing_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("BoTorch is required for the qNEI baseline; install 'constelx[bo]'")
+
+    monkeypatch.setattr("constelx.optim.baselines.run_botorch_qnei", _raise)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "opt",
+            "run",
+            "--baseline",
+            "qnei",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "BoTorch is required" in result.stdout or "BoTorch is required" in result.stderr

--- a/tests/test_optim_baselines.py
+++ b/tests/test_optim_baselines.py
@@ -5,12 +5,20 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from constelx.optim.baselines import BaselineConfig, run_ngopt
+from constelx.optim.baselines import BaselineConfig, run_botorch_qnei, run_ngopt
 
 
 def test_run_ngopt_returns_solution(tmp_path: Path) -> None:
     pytest.importorskip("nevergrad")
     cfg = BaselineConfig(budget=5, cache_dir=tmp_path)
     x, score = run_ngopt(cfg)
+    assert x.shape == (2,)
+    assert np.isfinite(score)
+
+
+def test_run_botorch_qnei_returns_solution(tmp_path: Path) -> None:
+    pytest.importorskip("botorch")
+    cfg = BaselineConfig(budget=6, cache_dir=tmp_path)
+    x, score = run_botorch_qnei(cfg)
     assert x.shape == (2,)
     assert np.isfinite(score)


### PR DESCRIPTION
**Summary**
- add a BoTorch qNEI baseline with feasibility-aware acquisition and modern sampling
- expose qnei via `constelx opt run` and update docs/tests/TODO tracking
- stabilize the loop by switching to qLogNEI and standardizing training data

**Testing**
- ruff format .
- ruff check .
- mypy src/constelx
- pytest -q
- pre-commit run -a

Closes #40